### PR TITLE
Fix loop in check_serial_port when connected via usbip

### DIFF
--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -155,6 +155,7 @@ def check_serial_port(serial_port: str) -> None:
 
 				if detected_model is not None:
 					break
+				time.sleep(1)	
 
 		finally:
 			stream.close()


### PR DESCRIPTION
When I tried running the integration over usbip, I encountered a problem in check_serial_port method. It looks like the reader thread is reading too fast and it reads the writer's  data before it gets flushed to the alarm control unit, so the unit never gets the data and never responds. As a quick fix, I added a sleep to the reader loop to slow down reading.
Actually is there a reason why the code is parallel? Can't the same thing be done in serial manner?