### PR TITLE
Added missing error log into check_serial_port method

### DIFF
--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -200,7 +200,8 @@ def check_serial_port(serial_port: str) -> None:
 			LOGGER.debug("Unsupported model: {}", model)
 			raise ModelNotSupported("Model {} not supported".format(model))
 
-	except (IndexError, FileNotFoundError, IsADirectoryError, UnboundLocalError, OSError):
+	except (IndexError, FileNotFoundError, IsADirectoryError, UnboundLocalError, OSError) as ex:
+		LOGGER.error(format(ex))
 		raise ServiceUnavailable
 
 	finally:


### PR DESCRIPTION
Added missing error log in the check_serial_port method. Spent few hours debugging with message "Jablotron is not available". I had to add this log to find out my /dev/hidraw0 was missing access for homeassistant system user.