### PR TITLE
Fix unauthorized when arming/disarming

### DIFF
--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -334,7 +334,7 @@ class Jablotron:
 			state_packet = self.int_to_bytes(int_packets[state] + section)
 			self._send_packets([
 				Jablotron.create_packet_authorisation_code(code),
-				Jablotron.create_packet_ui_control(JABLOTRON_UI_CONTROL_MODIFY_SECTION, state_packet)
+				Jablotron.create_packet_ui_control(UI_CONTROL_MODIFY_SECTION, state_packet)
 			])
 
 		after_packets = []

--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -332,7 +332,10 @@ class Jablotron:
 
 		if self._successful_login is True:
 			state_packet = self.int_to_bytes(int_packets[state] + section)
-			self._send_packet(self.create_packet_ui_control(UI_CONTROL_MODIFY_SECTION, state_packet))
+			self._send_packets([
+				Jablotron.create_packet_authorisation_code(code),
+				Jablotron.create_packet_ui_control(JABLOTRON_UI_CONTROL_MODIFY_SECTION, state_packet)
+			])
 
 		after_packets = []
 


### PR DESCRIPTION
I am sometimes unable to arm/disarm the alarm, because it is unauthorized for some reason (maybe timeout between keepalives). Adding authorization before the command fixed the problem for me, but not sure it's the right solution.