### PR TITLE
feat: autodetection of port

### DIFF
--- a/custom_components/jablotron100/config_flow.py
+++ b/custom_components/jablotron100/config_flow.py
@@ -172,7 +172,14 @@ class JablotronConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 				await self.async_set_unique_id(unique_id)
 				self._abort_if_unique_id_configured()
 
-				check_serial_port(user_input[CONF_SERIAL_PORT])
+				if user_input[CONF_SERIAL_PORT] != "auto":
+					check_serial_port(user_input[CONF_SERIAL_PORT])
+				else:
+					detected_port = Jablotron.detect_jablotron()
+					if not detected_port:
+						LOGGER.error("No Jablotron port found")
+						raise ServiceUnavailable
+					check_serial_port(detected_port)
 
 				self._config = {
 					CONF_UNIQUE_ID: user_input[CONF_SERIAL_PORT],


### PR DESCRIPTION
New feature

If port is set to auto, device port is autodetected via VID PID. This feature is useful on instable connection, where port is moving between /dev/hidrawX. Only integration reload should be enough to follow port migration.

Testing in progress