### PR TITLE
Improve support for Indexa 9000 (JA-14K) central units

### DIFF
--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -1783,7 +1783,7 @@ class Jablotron:
 		return None
 
 	def _is_central_unit_101_or_similar(self) -> bool:
-		return self._central_unit.model in ("JA-101K", "JA-101K-LAN", "JA-106K-3G")
+		return self._central_unit.model in ("JA-101K", "JA-101K-LAN", "JA-106K-3G", "JA-14K")
 
 	def _is_central_unit_103_or_similar(self) -> bool:
 		return self._central_unit.model in ("JA-103K", "JA-103KRY", "JA-107K")


### PR DESCRIPTION
This improves support for JA-14K central units by marking them as JA-101 similar systems. This adds sensors for the following three devices:

* Power Supply (device 124)
* LAN Network (device 125)
* GSM Network (device 127)

The related messages look like this:

```
2025-07-13 20:44:06.752 DEBUG (ThreadPoolExecutor-5_0) [custom_components.jablotron100] Incoming (device 124): 52188a7c0a888a008805008a108800008a118800008a01885f00
2025-07-13 20:44:06.752 DEBUG (ThreadPoolExecutor-5_0) [custom_components.jablotron100] Incoming (device 127): 52088a7fa40000000000
2025-07-13 20:44:06.752 DEBUG (ThreadPoolExecutor-5_0) [custom_components.jablotron100] Incoming (device 125): 52088a7da683c0a8b231
```

The GSM signal strength might be improved, but I'm unsure if it's included in the messages above.

Best regards,
Roland