### PR TITLE
Auto-recover serial port when configured hidraw path changes

### DIFF
--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -278,6 +278,26 @@ class Jablotron:
 		else:
 			self._serial_port = self._config[CONF_SERIAL_PORT]
 
+			# The hidraw device numbering can change across reboots when other USB
+			# HID devices are connected. If the configured path no longer points to
+			# a Jablotron device, transparently fall back to autodetection by USB
+			# vendor/product ID so the user does not have to reconfigure.
+			if not await self._hass.async_add_executor_job(
+				Jablotron._is_jablotron_serial_port, self._serial_port
+			):
+				LOGGER.warning(
+					"Configured serial port %s does not point to a Jablotron device, attempting autodetection",
+					self._serial_port,
+				)
+				detected_serial_port = await self._detect_serial_port()
+				if detected_serial_port is not None:
+					LOGGER.warning(
+						"Using autodetected serial port %s instead of configured %s",
+						detected_serial_port,
+						self._config[CONF_SERIAL_PORT],
+					)
+					self._serial_port = detected_serial_port
+
 		self._detect_central_unit()
 		await self._detect_and_create_devices_and_sections_and_pg_outputs()
 		self._create_central_unit_sensors()
@@ -2753,13 +2773,26 @@ class Jablotron:
 	@staticmethod
 	def _check_possible_paths_for_serial_port(possible_paths: list[str]) -> str | None:
 		for possible_path in possible_paths:
-			possible_realpath = os.path.realpath("{}/{}".format(HIDRAW_PATH, possible_path))
-			if "16D6:0008" in possible_realpath:
-				serial_port = "/dev/{}".format(possible_path)
+			serial_port = "/dev/{}".format(possible_path)
+			if Jablotron._is_jablotron_serial_port(serial_port):
 				LOGGER.debug("Detected serial port: {}".format(serial_port))
 				return serial_port
 
 		return None
+
+	@staticmethod
+	def _is_jablotron_serial_port(serial_port: str) -> bool:
+		device_name = os.path.basename(serial_port)
+		if not device_name:
+			return False
+
+		try:
+			realpath = os.path.realpath("{}/{}".format(HIDRAW_PATH, device_name))
+		except OSError as ex:
+			LOGGER.debug("Failed to verify serial port %s: %s", serial_port, ex)
+			return False
+
+		return "16D6:0008" in realpath
 
 
 class JablotronEntity(Entity):


### PR DESCRIPTION
## Problem

When a Home Assistant host has another USB HID device attached besides the Jablotron USB cable, the kernel's hidraw device numbering can change across reboots depending on enumeration order. The integration then ends up pointing at a wrong `/dev/hidrawN` and fails to start until the user opens the integration's *Reconfigure* dialog and manually swaps `/dev/hidraw0` ↔ `/dev/hidraw1` (or similar).

The autodetection logic (USB vendor/product ID `16D6:0008`) already exists, but only runs when the user picks the `auto` value in the serial port field. Users who have a specific `/dev/hidrawN` saved (often because they configured it long ago) get no benefit from it.

## Change

Reuse the existing autodetection as a transparent fallback:

* If an explicitly configured `/dev/hidrawN` no longer resolves to a device with VID/PID `16D6:0008`, the integration logs a warning and falls back to the same scan that the `auto` mode uses.
* The configured value in the config entry is **not modified** — only the in-memory `self._serial_port` for the current run is replaced. So if the user later moves their devices around again, behaviour stays predictable and the original setting is still there.
* If autodetection also finds nothing, behaviour is unchanged (the existing open/read failure path triggers as before).

A small helper `Jablotron._is_jablotron_serial_port()` performs the VID/PID check via `/sys/class/hidraw/<name>` realpath inspection, mirroring the logic already used by `_check_possible_paths_for_serial_port()`.

## Notes

* No config flow / strings / translation changes — the fix is fully transparent for existing users.
* Users who prefer a permanent fix can still create a udev rule mapping the Jablotron VID/PID to a stable symlink (e.g. `/dev/jablotron`), but that requires host access which is not always available (e.g. HAOS).
* Tested on a setup with a second HID dongle that was sometimes claiming `hidraw0` before the Jablotron cable.
