### PR TITLE
Preserve stored data when integration entry is reloaded

### DIFF
--- a/custom_components/jablotron100/__init__.py
+++ b/custom_components/jablotron100/__init__.py
@@ -3,14 +3,15 @@
 from homeassistant.const import Platform
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, storage
 from typing import Final
 
 from .const import (
+	CONF_SERIAL_PORT,
+	CONF_UNIQUE_ID,
 	DOMAIN,
-	LOGGER,
 )
-from .jablotron import Jablotron
+from .jablotron import Jablotron, STORAGE_VERSION
 
 
 type JablotronConfigEntry = ConfigEntry[Jablotron]
@@ -54,9 +55,26 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: JablotronConfigEn
 async def async_unload_entry(hass: HomeAssistant, config_entry: JablotronConfigEntry) -> bool:
 	await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
 
-	config_entry.runtime_data.shutdown_and_clean()
+	# Only stop the running instance. Stored data must be preserved so reloads
+	# (e.g. after changing options) do not have to re-detect every device.
+	config_entry.runtime_data.shutdown()
 
 	return True
+
+
+async def async_remove_entry(hass: HomeAssistant, config_entry: JablotronConfigEntry) -> None:
+	"""Remove the integration's persisted data when the user deletes the entry."""
+	unique_id = config_entry.data.get(CONF_UNIQUE_ID, config_entry.data.get(CONF_SERIAL_PORT))
+	if unique_id is None:
+		return
+
+	store: storage.Store = storage.Store(hass, STORAGE_VERSION, DOMAIN)
+	stored_data = await store.async_load()
+	if not stored_data or unique_id not in stored_data:
+		return
+
+	del stored_data[unique_id]
+	await store.async_save(stored_data)
 
 
 async def options_update_listener(hass: HomeAssistant, config_entry: JablotronConfigEntry) -> None:

--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -303,8 +303,9 @@ class Jablotron:
 		self.shutdown()
 
 		unique_id = self._get_unique_id()
-		del self._stored_data[unique_id]
-		self._store_data_to_store_threadsafe()
+		if self._stored_data is not None and unique_id in self._stored_data:
+			del self._stored_data[unique_id]
+			self._store_data_to_store_threadsafe()
 
 	def shutdown(self) -> None:
 		self._stream_stop_event.set()


### PR DESCRIPTION
## Problem

`async_unload_entry` calls `Jablotron.shutdown_and_clean()`, which deletes the entry's persisted data from the integration's `Store` (devices, central unit info, last known states). This runs on every reload — including options changes and `Reconfigure`. As a result:

* Every reload triggers a full re-detection of devices and sections (slow, generates extra serial traffic).
* Last known entity states are lost, so entities briefly show `unknown` after every reload.
* `shutdown_and_clean` performs `del self._stored_data[unique_id]` without an existence check, raising `KeyError` if invoked twice.
* There is no `async_remove_entry` hook, so `shutdown_and_clean` was effectively the only place that ever cleared the data — coupling cleanup with reload.

## Change

* `async_unload_entry` now only calls `shutdown()` — keep persisted data across reloads.
* New `async_remove_entry` hook removes only this entry's data from the store when the user actually deletes the integration. It uses `Store` directly so it works even when no `Jablotron` instance is around.
* `shutdown_and_clean` now guards the `del` so it is idempotent.

## Notes

* Behaviour for fresh installs and full removals is unchanged.
* Reload time is faster because the existing `_detect_*` paths short-circuit when stored data is present.
* `STORAGE_VERSION` is exported from `jablotron.py` (already a module-level `Final`) so `__init__.py` opens the same store with the same version.
