### PR TITLE
Wait up to 2s for diagnostics response instead of always 0.5s

### DIFF
--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -955,8 +955,10 @@ class Jablotron:
 				self._create_packet_device_diagnostics_force_info(device_number),
 			])
 
-			while not self._stream_diagnostics_event.wait(0.5):
-				break
+			# Wait up to 2 seconds for the diagnostics response packet.
+			# The previous "while ... wait(0.5): break" pattern always exited
+			# after a single 0.5s wait regardless of whether the event fired.
+			self._stream_diagnostics_event.wait(2.0)
 
 			self._send_packet(self._create_packet_device_diagnostics_end(device_number))
 


### PR DESCRIPTION
## Problem

`_force_devices_info_update` waits for the diagnostics response with:

```python
while not self._stream_diagnostics_event.wait(0.5):
    break
```

The unconditional `break` makes the loop exit after the first iteration regardless of whether `wait()` returned `True` or `False`. The intended "wait until the event fires (with periodic checks)" is in fact "wait at most 0.5 seconds, then continue". If the diagnostics response arrives at e.g. 0.6 s, the integration gives up too early and sends the diagnostics-end packet before the device has actually responded — causing missing temperature, voltage and bus readings on slower devices.

## Change

Replace the bogus loop with a single `wait(2.0)`. The behaviour is now: wait up to 2 seconds for the diagnostics response, then proceed regardless.

## Notes

* No protocol-level change.
* Total worst-case latency per device increases from 0.5 s to 2 s, but only when the device is slow to respond. In practice most devices respond within milliseconds, so `wait()` returns immediately.
* The 2 s value matches the order of magnitude of other timeouts in the integration (e.g. `STREAM_TIMEOUT = 10` for initial detection).
