### PR TITLE
Avoid KeyError when entity state is queried before initialisation

### DIFF
--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -2827,4 +2827,4 @@ class JablotronEntity(Entity):
 		self.refresh_state()
 
 	def _get_state(self) -> StateType | AlarmControlPanelState:
-		return self._jablotron.entities_states[self._control.id]
+		return self._jablotron.entities_states.get(self._control.id)


### PR DESCRIPTION
## Problem

`JablotronEntity._get_state` does a direct `dict[key]` lookup against `entities_states`. If an entity is queried before its initial state has been written (timing window during startup, or after a `_remove_entity` race), the lookup raises `KeyError` instead of reporting the entity as unavailable.

`available` already tolerates `None` (it returns `False` when `_get_state()` is None), but never gets a chance to run because the exception bubbles out of `_get_state` first.

## Change

Use `dict.get()` so a missing key yields `None` and the entity reports unavailable, matching the existing semantics of `available`.

## Notes

* No behavioural change in the normal case — `_get_state` still returns the same value when the key exists.
* Only affects the (rare) edge case where the entity is asked for its state before initialisation.
