### PR TITLE
Use explicit little-endian byte order for protocol conversions

### DIFF
--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -22,7 +22,6 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.helpers import entity_registry as er
 import math
 import os
-import sys
 import threading
 import time
 from .const import (
@@ -2643,7 +2642,7 @@ class Jablotron:
 
 	@staticmethod
 	def bytes_to_int(packet: bytes) -> int:
-		return int.from_bytes(packet, byteorder=sys.byteorder)
+		return int.from_bytes(packet, byteorder="little")
 
 	@staticmethod
 	def bytes_to_float(packet: bytes) -> float:
@@ -2655,7 +2654,7 @@ class Jablotron:
 
 	@staticmethod
 	def int_to_bytes(number: int) -> bytes:
-		return int.to_bytes(number, 1, byteorder=sys.byteorder)
+		return int.to_bytes(number, 1, byteorder="little")
 
 	@staticmethod
 	def create_packet(packet_type: bytes, data: bytes) -> bytes:


### PR DESCRIPTION
## Problem

`bytes_to_int` and `int_to_bytes` use `byteorder=sys.byteorder`. The Jablotron serial protocol is fixed-endian (little-endian), so the conversion result depends on the host's CPU architecture. On any big-endian Home Assistant host, all parsed numbers (device numbers, signal strength, sensor values, packet lengths) would silently produce wrong values.

In practice every supported HA platform is little-endian, so the bug never manifests today. But the code is also unnecessarily coupled to the host architecture — the protocol byte order is a property of the wire format, not the host.

## Change

Pin both helpers to `byteorder="little"`. The unused `import sys` is removed.

## Notes

* No behavioural change on any little-endian host (i.e. all known HA installs).
* Removes a latent portability bug.
