### PR TITLE
Narrow except in info subpacket parser to ValueError

### DIFF
--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -2344,7 +2344,7 @@ class Jablotron:
 				if not info_type.is_unknown():
 					info_packets.append(ParsedDeviceInfoPacket(info_type, info_subpacket[start:end]))
 
-			except Exception:
+			except ValueError:
 				Jablotron._log_error_with_packet(
 					"Unknown device info type {}".format(info_type_int),
 					packet,


### PR DESCRIPTION
## Change

Narrow `except Exception` to `except ValueError` in `_parse_device_info_packets_from_device_info_subpacket`.

The only operation in the `try` block that can fail with a normal expected error is `DeviceInfoType(info_type_int)`, which raises `ValueError` for unknown enum values. The bare `except Exception` would also swallow real bugs (e.g. `AttributeError` from `is_unknown()` or `TypeError` from the append) and silently log them as "Unknown device info type", masking the underlying problem.
