### PR TITLE
Use integer floor division when computing authorized user number

### DIFF
--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -2145,7 +2145,10 @@ class Jablotron:
 		if device_number in (DeviceNumber.MOBILE_APPLICATION.value, DeviceNumber.USB.value):
 			offset = offset - 1
 
-		user_no = int((self.bytes_to_int(packet[3:4]) - offset) / 4)
+		# Each user occupies 4 consecutive values in the packet byte after the
+		# fixed offset, so // 4 converts the offset-relative position into the
+		# user number.
+		user_no = (self.bytes_to_int(packet[3:4]) - offset) // 4
 		self._last_authorized_user_or_device = "User {}".format(user_no)
 		LOGGER.debug("Authorized user: {}".format(user_no))
 


### PR DESCRIPTION
## Change

Use integer floor division instead of `int(... / 4)` when computing the authorized `user_no` from the device-state packet.

`int(float)` truncates towards zero, which produces the wrong result for negative inputs (e.g. `int(-3.5)` → `-3`, while `-7 // 2` → `-4`). With correct protocol input the result is always non-negative, so this is not a current bug — but `//` is the right operator for "divide and floor" and avoids the unnecessary int → float → int round-trip.
