### PR TITLE
docs: drop 'OS' from 'Restart Home Assistant OS' in pre-install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Tested with JA-100K, JA-101K, JA-101K-LAN, JA-103K, JA-103KRY, JA-106K-3G, JA-10
 ## Before installation
 
 1. Connect the USB cable to Jablotron central unit
-2. Restart the Home Assistant OS
+2. Restart Home Assistant
 
 ## Installation
 


### PR DESCRIPTION
The integration works on every Home Assistant install variant (Container, Supervised, OS, Core), not only HAOS. The phrasing already used elsewhere in the README is just `Restart Home Assistant`.