### PR TITLE
Demote log level for packets from system-reserved device numbers

### DIFF
--- a/custom_components/jablotron100/const.py
+++ b/custom_components/jablotron100/const.py
@@ -61,6 +61,15 @@ class DeviceNumber(Enum):
 	USB = 254
 
 
+# Device numbers in this range are reserved by the central unit for system /
+# control entities (mobile applications, F-Link, USB connection, ...). They are
+# never assigned to user-installed peripherals on any supported central unit
+# (JA-101K supports up to 50 devices, JA-103K up to 120, JA-107K up to 230),
+# so packets coming from such numbers are not bugs — just system traffic that
+# we may not have explicit handling for yet.
+SYSTEM_DEVICE_NUMBER_RESERVED_MIN: Final = 240
+
+
 class DeviceType(StrEnum):
 	CENTRAL_UNIT = "central_unit"
 	KEYPAD = "keypad"

--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -95,6 +95,7 @@ from .const import (
 	STREAM_MAX_WORKERS,
 	STREAM_PACKET_SIZE,
 	STREAM_TIMEOUT,
+	SYSTEM_DEVICE_NUMBER_RESERVED_MIN,
 	SectionPrimaryState,
 	SystemInfo,
 	TIMEOUT_FOR_DEVICE_STATE_PACKETS,
@@ -1363,7 +1364,10 @@ class Jablotron:
 			return
 
 		if device_number > self._config[CONF_NUMBER_OF_DEVICES]:
-			self._log_error_with_packet("State packet of unknown device", packet)
+			if device_number >= SYSTEM_DEVICE_NUMBER_RESERVED_MIN:
+				self._log_debug_with_packet("State packet of system device", packet)
+			else:
+				self._log_error_with_packet("State packet of unknown device", packet)
 			return
 
 		device_type = self._get_device_type(device_number)
@@ -1447,7 +1451,10 @@ class Jablotron:
 		if device_number in (lan_connection_number, gsm_device_number):
 			pass
 		elif device_number > self._config[CONF_NUMBER_OF_DEVICES]:
-			self._log_error_with_packet("Info packet of unknown device", packet)
+			if device_number >= SYSTEM_DEVICE_NUMBER_RESERVED_MIN:
+				self._log_debug_with_packet("Info packet of system device", packet)
+			else:
+				self._log_error_with_packet("Info packet of unknown device", packet)
 			return
 
 		subpackets = self._parse_device_info_subpackets_from_device_info_packet(packet)


### PR DESCRIPTION
## What

Demote `State packet of unknown device` and `Info packet of unknown device`
errors to debug level when the device number falls in the central-unit's
system-reserved range (>= 240).

## Why

Several open issues report identical-looking ERROR log spam coming from device
numbers that are not real user-installed peripherals:

- #112 — `State packet of unknown device (device 250)` on JA-101K (mobile
  application instance)
- #123 — `State packet of unknown device (device 248)` on JA-107K

The existing code already special-cases two of these reserved numbers
(`MOBILE_APPLICATION = 251`, `USB = 254`) in `DeviceNumber`, but other
system entities (additional mobile-app sessions, F-Link, etc.) can also send
state/info packets and currently produce a misleading error for every packet.

The integration is working correctly in those cases — the packet just comes
from a system entity rather than a configured peripheral, so an error is the
wrong log level.

## How

- New constant `SYSTEM_DEVICE_NUMBER_RESERVED_MIN = 240` in `const.py`.
  Threshold chosen to stay above the maximum number of user peripherals on
  any supported central unit (JA-101K: 50, JA-103K: 120, JA-107K: 230).
- In both `_parse_device_state_packet` and `_parse_device_info_packet`, when
  `device_number > CONF_NUMBER_OF_DEVICES`, branch on the new threshold:
  - `>= 240` → `LOGGER.debug("... of system device", ...)`
  - `< 240` → original error log preserved (so genuine bugs like a packet
    for a not-yet-configured peripheral still surface).

## Not in scope

- #119 (device 121) — that number is below the threshold; it could be a real
  device on a JA-107K or some other internal usage. Needs separate
  investigation.
- Decoding what 248 / 250 actually represent — this PR only stops the error
  spam; the packets are still visible at debug level for anyone who wants to
  reverse-engineer them later.

## Testing

- Static type / lint check (no errors).
- Logic is a pure log-level demotion guarded by a numeric range; control
  flow for normal device numbers is unchanged.

Closes #112
Closes #123
