### PR TITLE
Show clearer error when no Jablotron USB device is detected

### DIFF
--- a/custom_components/jablotron100/config_flow.py
+++ b/custom_components/jablotron100/config_flow.py
@@ -49,6 +49,7 @@ from .const import (
 from .errors import (
 	ModelNotDetected,
 	ModelNotSupported,
+	SerialPortNotDetected,
 	ServiceUnavailable,
 )
 from .jablotron import Jablotron
@@ -183,7 +184,7 @@ class JablotronConfigFlow(ConfigFlow, domain=DOMAIN):
 
 					if serial_port is None:
 						LOGGER.error("No serial port found")
-						raise ServiceUnavailable
+						raise SerialPortNotDetected
 				else:
 					serial_port = user_input[CONF_SERIAL_PORT]
 
@@ -211,6 +212,9 @@ class JablotronConfigFlow(ConfigFlow, domain=DOMAIN):
 
 			except ModelNotSupported:
 				errors["base"] = "model_not_supported"
+
+			except SerialPortNotDetected:
+				errors["base"] = "serial_port_not_detected"
 
 			except ServiceUnavailable:
 				errors["base"] = "service_unavailable"
@@ -293,7 +297,7 @@ class JablotronConfigFlow(ConfigFlow, domain=DOMAIN):
 						)
 						if detected_serial_port is None:
 							LOGGER.error("No serial port found")
-							raise ServiceUnavailable
+							raise SerialPortNotDetected
 
 						serial_port_to_check = detected_serial_port
 					else:
@@ -306,6 +310,9 @@ class JablotronConfigFlow(ConfigFlow, domain=DOMAIN):
 					validation_failed = True
 				except ModelNotSupported:
 					errors[CONF_SERIAL_PORT] = "model_not_supported"
+					validation_failed = True
+				except SerialPortNotDetected:
+					errors[CONF_SERIAL_PORT] = "serial_port_not_detected"
 					validation_failed = True
 				except ServiceUnavailable:
 					errors[CONF_SERIAL_PORT] = "service_unavailable"

--- a/custom_components/jablotron100/errors.py
+++ b/custom_components/jablotron100/errors.py
@@ -10,6 +10,10 @@ class ServiceUnavailable(JablotronException):
 	"""Service is not available."""
 
 
+class SerialPortNotDetected(JablotronException):
+	"""No Jablotron device was detected on the host."""
+
+
 class ModelNotDetected(JablotronException):
 	"""Model not detected."""
 

--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -106,9 +106,10 @@ from .const import (
 )
 from typing import Any, Dict, Final, List, Mapping
 from .errors import (
+	InvalidBatteryLevel,
+	SerialPortNotDetected,
 	ServiceUnavailable,
 	ShouldNotHappen,
-	InvalidBatteryLevel,
 )
 
 STORAGE_VERSION: Final = 2
@@ -275,7 +276,7 @@ class Jablotron:
 		if self._config[CONF_SERIAL_PORT] == AUTODETECT_SERIAL_PORT:
 			self._serial_port = await self._detect_serial_port()
 			if self._serial_port is None:
-				raise ServiceUnavailable("No serial port found")
+				raise SerialPortNotDetected("No Jablotron USB device detected")
 		else:
 			self._serial_port = self._config[CONF_SERIAL_PORT]
 
@@ -2775,10 +2776,20 @@ class Jablotron:
 
 	@staticmethod
 	def detect_serial_port() -> str | None:
-		return Jablotron._check_possible_paths_for_serial_port(os.listdir(HIDRAW_PATH))
+		try:
+			possible_paths = os.listdir(HIDRAW_PATH)
+		except OSError as ex:
+			LOGGER.debug("Failed to list %s: %s", HIDRAW_PATH, ex)
+			return None
+
+		return Jablotron._check_possible_paths_for_serial_port(possible_paths)
 
 	async def _detect_serial_port(self) -> str | None:
-		possible_paths = await self._hass.async_add_executor_job(os.listdir, HIDRAW_PATH)
+		try:
+			possible_paths = await self._hass.async_add_executor_job(os.listdir, HIDRAW_PATH)
+		except OSError as ex:
+			LOGGER.debug("Failed to list %s: %s", HIDRAW_PATH, ex)
+			return None
 
 		return Jablotron._check_possible_paths_for_serial_port(possible_paths)
 

--- a/custom_components/jablotron100/strings.json
+++ b/custom_components/jablotron100/strings.json
@@ -495,7 +495,8 @@
 		"error": {
 			"service_unavailable": "Jablotron is not available",
 			"model_not_detected": "Model of Jablotron not detected",
-			"model_not_supported": "Model of Jablotron not supported"
+			"model_not_supported": "Model of Jablotron not supported",
+			"serial_port_not_detected": "No Jablotron USB device was detected. Make sure the device is connected and visible to the operating system."
 		},
 		"abort": {
 			"already_configured": "Jablotron is already configured",

--- a/custom_components/jablotron100/translations/cs.json
+++ b/custom_components/jablotron100/translations/cs.json
@@ -495,7 +495,8 @@
 		"error": {
 			"service_unavailable": "Jablotron není dostupný",
 			"model_not_detected": "Typ ústředny Jablotron nebyl rozpoznán",
-			"model_not_supported": "Typ ústředny Jablotron není podporován"
+			"model_not_supported": "Typ ústředny Jablotron není podporován",
+			"serial_port_not_detected": "Žádné USB zařízení Jablotron nebylo nalezeno. Zkontrolujte, zda je zařízení připojené a viditelné pro operační systém."
 		},
 		"abort": {
 			"already_configured": "Jablotron je již nastaven",

--- a/custom_components/jablotron100/translations/da.json
+++ b/custom_components/jablotron100/translations/da.json
@@ -495,7 +495,8 @@
 		"error": {
 			"service_unavailable": "Jablotron er ikke tilgænglig",
 			"model_not_detected": "Jablotron model ikke fundet",
-			"model_not_supported": "Jablotron model understøttes ikke"
+			"model_not_supported": "Jablotron model understøttes ikke",
+			"serial_port_not_detected": "Ingen Jablotron USB-enhed blev fundet. Kontrollér at enheden er tilsluttet og synlig for operativsystemet."
 		},
 		"abort": {
 			"already_configured": "Jablotron er allerede konfigureret",

--- a/custom_components/jablotron100/translations/de.json
+++ b/custom_components/jablotron100/translations/de.json
@@ -495,7 +495,8 @@
 		"error": {
 			"service_unavailable": "Jablotron ist nicht verfügbar",
 			"model_not_detected": "Der Jablotron Anlagentyp konnte nicht erkannt werden",
-			"model_not_supported": "Der Jablotron Anlagentyp wird nicht unterstützt"
+			"model_not_supported": "Der Jablotron Anlagentyp wird nicht unterstützt",
+			"serial_port_not_detected": "Es wurde kein Jablotron USB-Gerät erkannt. Stellen Sie sicher, dass das Gerät angeschlossen und für das Betriebssystem sichtbar ist."
 		},
 		"abort": {
 			"already_configured": "Die Jablotron Anlage ist bereits konfiguriert",

--- a/custom_components/jablotron100/translations/en.json
+++ b/custom_components/jablotron100/translations/en.json
@@ -495,7 +495,8 @@
 		"error": {
 			"service_unavailable": "Jablotron is not available",
 			"model_not_detected": "Model of Jablotron not detected",
-			"model_not_supported": "Model of Jablotron not supported"
+			"model_not_supported": "Model of Jablotron not supported",
+			"serial_port_not_detected": "No Jablotron USB device was detected. Make sure the device is connected and visible to the operating system."
 		},
 		"abort": {
 			"already_configured": "Jablotron is already configured",

--- a/custom_components/jablotron100/translations/it.json
+++ b/custom_components/jablotron100/translations/it.json
@@ -495,7 +495,8 @@
 		"error": {
 			"service_unavailable": "Jablotron non è disponibile",
 			"model_not_detected": "Modello Jablotron non rilevato",
-			"model_not_supported": "Modello Jablotron non supportato"
+			"model_not_supported": "Modello Jablotron non supportato",
+			"serial_port_not_detected": "Nessun dispositivo USB Jablotron rilevato. Assicurati che il dispositivo sia collegato e visibile al sistema operativo."
 		},
 		"abort": {
 			"already_configured": "Jablotron è già configurato",

--- a/custom_components/jablotron100/translations/nb.json
+++ b/custom_components/jablotron100/translations/nb.json
@@ -495,7 +495,8 @@
 		"error": {
 			"service_unavailable": "Jablotron er ikke tilgjengelig",
 			"model_not_detected": "Jablotron-modellen ble ikke funnet",
-			"model_not_supported": "Jablotron-modellen støttes ikke"
+			"model_not_supported": "Jablotron-modellen støttes ikke",
+			"serial_port_not_detected": "Ingen Jablotron USB-enhet ble funnet. Kontroller at enheten er tilkoblet og synlig for operativsystemet."
 		},
 		"abort": {
 			"already_configured": "Jablotron er allerede konfigurert",

--- a/custom_components/jablotron100/translations/nl.json
+++ b/custom_components/jablotron100/translations/nl.json
@@ -495,7 +495,8 @@
 		"error": {
 			"service_unavailable": "Jablotron is niet gevonden",
 			"model_not_detected": "Jablotron model niet gedetecteerd",
-			"model_not_supported": "Jablotron model niet ondersteund"
+			"model_not_supported": "Jablotron model niet ondersteund",
+			"serial_port_not_detected": "Er is geen Jablotron USB-apparaat gedetecteerd. Controleer of het apparaat is aangesloten en zichtbaar is voor het besturingssysteem."
 		},
 		"abort": {
 			"already_configured": "Jablotron is al geconfigureerd",

--- a/custom_components/jablotron100/translations/sk.json
+++ b/custom_components/jablotron100/translations/sk.json
@@ -495,7 +495,8 @@
 		"error": {
 			"service_unavailable": "Jablotron nie je dostupný",
 			"model_not_detected": "Typ ústredne Jablotron nebol rozpoznaný",
-			"model_not_supported": "Typ ústredne Jablotron nie je podporovaný"
+			"model_not_supported": "Typ ústredne Jablotron nie je podporovaný",
+			"serial_port_not_detected": "Žiadne USB zariadenie Jablotron nebolo nájdené. Skontrolujte, či je zariadenie pripojené a viditelné pre operačný systém."
 		},
 		"abort": {
 			"already_configured": "Jablotron je už nakonfigurovaný",


### PR DESCRIPTION
When a user keeps the default `Autodetect` option in the config flow but no Jablotron USB device is connected (or the integration runs on a host without `/sys/class/hidraw`), the form used to show the generic `Jablotron is not available` message. That same wording is reused for unrelated runtime errors and gives no hint that the actual problem is a missing/unplugged device, which makes reports like #109 hard to debug.

This PR:

- Adds a dedicated `SerialPortNotDetected` exception.
- Raises it from autodetect both in the config flow (`async_step_user` / `async_step_reconfigure_settings`) and at runtime `Jablotron.initialize()`.
- Makes `detect_serial_port()` / `_detect_serial_port()` return `None` (instead of crashing) when `/sys/class/hidraw` is missing.
- Adds a new translatable `serial_port_not_detected` error string in `strings.json` and all 8 translation files.

Users now see an actionable message such as `No Jablotron USB device was detected. Make sure the device is connected and visible to the operating system.` instead of the generic one.

Refs #109