### PR TITLE
Recover automatically when the USB stream drops

### DIFF
--- a/custom_components/jablotron100/const.py
+++ b/custom_components/jablotron100/const.py
@@ -156,6 +156,11 @@ CODE_MAX_LENGTH: Final = 10
 STREAM_MAX_WORKERS: Final = 5
 STREAM_TIMEOUT: Final = 10
 STREAM_PACKET_SIZE: Final = 64
+# Initial delay (in seconds) before retrying to reopen the serial port stream
+# after an I/O error. Multiplied by the number of consecutive failures and
+# capped at STREAM_REOPEN_MAX_DELAY to back off when the device is gone.
+STREAM_REOPEN_DELAY: Final = 1
+STREAM_REOPEN_MAX_DELAY: Final = 30
 
 MAX_SECTIONS: Final = 15
 MAX_DEVICES: Final = 230

--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -94,6 +94,8 @@ from .const import (
 	SIGNAL_STRENGTH_STEP,
 	STREAM_MAX_WORKERS,
 	STREAM_PACKET_SIZE,
+	STREAM_REOPEN_DELAY,
+	STREAM_REOPEN_MAX_DELAY,
 	STREAM_TIMEOUT,
 	SYSTEM_DEVICE_NUMBER_RESERVED_MIN,
 	SectionPrimaryState,
@@ -1013,10 +1015,14 @@ class Jablotron:
 	def _read_packets(self) -> None:
 		stream = self._open_read_stream()
 		last_restarted_at_hour = datetime.datetime.now().hour
+		consecutive_errors = 0
 
 		while not self._stream_stop_event.is_set():
 
 			try:
+
+				if stream is None:
+					stream = self._open_read_stream()
 
 				while True:
 
@@ -1077,13 +1083,34 @@ class Jablotron:
 
 					break
 
+				consecutive_errors = 0
+				time.sleep(0.5)
+
 			except Exception as ex:
-				LOGGER.exception("Read error: %s", ex)
+				if consecutive_errors == 0:
+					LOGGER.exception("Read error: %s", ex)
+				else:
+					LOGGER.debug("Read error: %s", ex)
+
 				self._set_unavailable()
 
-			time.sleep(0.5)
+				if stream is not None:
+					try:
+						stream.close()
+					except OSError:
+						pass
+					stream = None
 
-		stream.close()
+				self._redetect_serial_port()
+
+				consecutive_errors += 1
+				time.sleep(min(STREAM_REOPEN_DELAY * consecutive_errors, STREAM_REOPEN_MAX_DELAY))
+
+		if stream is not None:
+			try:
+				stream.close()
+			except OSError:
+				pass
 
 	def _keepalive(self):
 		counter = 0
@@ -1111,6 +1138,7 @@ class Jablotron:
 				except Exception as ex:
 					LOGGER.exception("Write error: %s", ex)
 					self._set_unavailable()
+					self._redetect_serial_port()
 
 				counter += 1
 			else:
@@ -1156,6 +1184,27 @@ class Jablotron:
 
 	def _open_read_stream(self):
 		return open(self._serial_port, "rb", buffering=0)
+
+	def _redetect_serial_port(self) -> None:
+		"""Re-run autodetection if the configured port is AUTODETECT_SERIAL_PORT.
+
+		Useful to recover when the operating system reassigns /dev/hidraw* after
+		a USB reset or when the device disappears and reappears under a different
+		path.
+		"""
+		if self._config[CONF_SERIAL_PORT] != AUTODETECT_SERIAL_PORT:
+			return
+
+		detected_serial_port = Jablotron.detect_serial_port()
+		if detected_serial_port is None or detected_serial_port == self._serial_port:
+			return
+
+		LOGGER.warning(
+			"Serial port changed from %s to %s",
+			self._serial_port,
+			detected_serial_port,
+		)
+		self._serial_port = detected_serial_port
 
 	def _is_alarm_active(self) -> bool:
 		for section_alarm_id in self.entities[EntityType.ALARM_CONTROL_PANEL]:


### PR DESCRIPTION
When the operating system briefly drops `/dev/hidraw*` (USB stack hiccup, port renumbering after a USB reset, ...), the integration used to keep failing on every read with the now-invalid stream object until the user reloaded the entry by hand. Several reports describe exactly this, e.g. #117 with errors like `[Errno 30] Read-only file system: '/dev/hidraw0'` and `[Errno 2] No such file or directory: '/dev/hidraw0'` that never recovered on their own.

This PR adds self-healing for the read and write loops:

- On a read error in `_read_packets`, close the failed stream, re-run autodetection (only if the user picked the autodetect option) so we follow the device when it reappears under a new path, try to reopen, and back off with an increasing delay capped at `STREAM_REOPEN_MAX_DELAY` so we do not spam the log when the device is truly gone.
- The full traceback is still logged on the first failure of a streak; subsequent retries log at `DEBUG` to avoid noise. Once a read succeeds again the counter resets and the integration silently goes back to available.
- The `_keepalive` (write) loop also re-runs autodetection on error so the next write picks up the new path. Each write already opens a fresh stream, so no extra reopen logic is needed there.

No behavior change when the device is healthy.

Refs #117