### PR TITLE
multi-select sections and dynamic add/edit/remove flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Tested with JA-100K, JA-101K, JA-101K-LAN, JA-103K, JA-103KRY, JA-106K-3G, JA-10
 - Event `jablotron100_wrong_code` is triggered when wrong code is inserted in Home Assistant.
 - Problem in a section is reported in specific "problem" sensor.
 
+### Common segments
+
+Jablotron 100 supports a "common segment" — a single button that arms or disarms multiple sections at once. You can mirror that behaviour in Home Assistant by defining virtual common segments in the integration options (*Settings → Devices & Services → Jablotron → Configure → Common segments*). Each common segment becomes its own `alarm_control_panel` entity that fans out arm/disarm commands to all listed sections, and reports a derived state (armed only when every constituent section is armed).
+
 ### Devices
 
 - Devices with two states (on/off, active/inactive, open/closed etc.) are supported.

--- a/custom_components/jablotron100/alarm_control_panel.py
+++ b/custom_components/jablotron100/alarm_control_panel.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from . import JablotronConfigEntry
 from .const import EntityType, PartiallyArmingMode
-from .jablotron import Jablotron, JablotronEntity, JablotronAlarmControlPanel
+from .jablotron import Jablotron, JablotronEntity, JablotronAlarmControlPanel, JablotronCommonSegment
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: JablotronConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
@@ -22,7 +22,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: JablotronConfigEn
 		entities = []
 
 		for entity in jablotron_instance.entities[EntityType.ALARM_CONTROL_PANEL].values():
-			if entity.id not in jablotron_instance.hass_entities:
+			if entity.id in jablotron_instance.hass_entities:
+				continue
+			if isinstance(entity, JablotronCommonSegment):
+				entities.append(JablotronCommonSegmentEntity(jablotron_instance, entity))
+			else:
 				entities.append(JablotronAlarmControlPanelEntity(jablotron_instance, entity))
 
 		async_add_entities(entities)
@@ -34,20 +38,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: JablotronConfigEn
 	)
 
 
-class JablotronAlarmControlPanelEntity(JablotronEntity, AlarmControlPanelEntity):
-	_control: JablotronAlarmControlPanel
-	_changed_by: str | None = None
+class _JablotronAlarmControlPanelEntityBase(JablotronEntity, AlarmControlPanelEntity):
 	_code_required_for_disarm: bool = False
 	_partially_arming_mode: PartiallyArmingMode
 
 	_attr_name = None
-
-	def __init__(
-		self,
-		jablotron: Jablotron,
-		control: JablotronAlarmControlPanel,
-	) -> None:
-		super().__init__(jablotron, control)
 
 	def _update_attributes(self) -> None:
 		super()._update_attributes()
@@ -58,32 +53,27 @@ class JablotronAlarmControlPanelEntity(JablotronEntity, AlarmControlPanelEntity)
 		self._attr_code_arm_required = self._jablotron.is_code_required_for_arm()
 		self._attr_supported_features = self._detect_supported_features()
 		self._attr_alarm_state = self._get_state()
-		self._attr_changed_by = self._changed_by
 		self._attr_code_format = self._detect_code_format()
 
 	def alarm_disarm(self, code: str | None = None) -> None:
 		if self._get_state() == AlarmControlPanelState.DISARMED:
 			return
 
-		code = JablotronAlarmControlPanelEntity._clean_code(code)
-		code = self.code_or_default_code(code)
-
+		code = self._resolve_code(code)
 		if code is None and self._code_required_for_disarm:
 			return
 
-		self._jablotron.modify_alarm_control_panel_section_state(self._control.section, AlarmControlPanelState.DISARMED, code)
+		self._modify_state(AlarmControlPanelState.DISARMED, code)
 
 	def alarm_arm_away(self, code: str | None = None) -> None:
 		if self._get_state() == AlarmControlPanelState.ARMED_AWAY:
 			return
 
-		code = JablotronAlarmControlPanelEntity._clean_code(code)
-		code = self.code_or_default_code(code)
-
+		code = self._resolve_code(code)
 		if code is None and self._attr_code_arm_required:
 			return
 
-		self._jablotron.modify_alarm_control_panel_section_state(self._control.section, AlarmControlPanelState.ARMED_AWAY, code)
+		self._modify_state(AlarmControlPanelState.ARMED_AWAY, code)
 
 	def alarm_arm_home(self, code: str | None = None) -> None:
 		self._arm_partially(AlarmControlPanelState.ARMED_HOME, code)
@@ -91,23 +81,22 @@ class JablotronAlarmControlPanelEntity(JablotronEntity, AlarmControlPanelEntity)
 	def alarm_arm_night(self, code: str | None = None) -> None:
 		self._arm_partially(AlarmControlPanelState.ARMED_NIGHT, code)
 
-	def update_state(self, state: StateType) -> None:
-		if self._get_state() != state:
-			self._changed_by = self._jablotron.last_authorized_user_or_device()
-
-		super().update_state(state)
-
 	def _arm_partially(self, state: AlarmControlPanelState, code: str | None = None) -> None:
 		if self._get_state() in (AlarmControlPanelState.ARMED_AWAY, AlarmControlPanelState.ARMED_HOME, AlarmControlPanelState.ARMED_NIGHT):
 			return
 
-		code = JablotronAlarmControlPanelEntity._clean_code(code)
-		code = self.code_or_default_code(code)
-
+		code = self._resolve_code(code)
 		if code is None and self._attr_code_arm_required:
 			return
 
-		self._jablotron.modify_alarm_control_panel_section_state(self._control.section, state, code)
+		self._modify_state(state, code)
+
+	def _resolve_code(self, code: str | None) -> str | None:
+		cleaned = None if code == "" else code
+		return self.code_or_default_code(cleaned)
+
+	def _modify_state(self, state: AlarmControlPanelState, code: str | None) -> None:
+		raise NotImplementedError
 
 	def _detect_supported_features(self) -> AlarmControlPanelEntityFeature:
 		if self._partially_arming_mode == PartiallyArmingMode.NOT_SUPPORTED:
@@ -129,6 +118,33 @@ class JablotronAlarmControlPanelEntity(JablotronEntity, AlarmControlPanelEntity)
 
 		return CodeFormat.TEXT if self._jablotron.code_contains_asterisk() is True else CodeFormat.NUMBER
 
-	@staticmethod
-	def _clean_code(code: str | None) -> str | None:
-		return None if code == "" else code
+
+class JablotronAlarmControlPanelEntity(_JablotronAlarmControlPanelEntityBase):
+	_control: JablotronAlarmControlPanel
+	_changed_by: str | None = None
+
+	def _update_attributes(self) -> None:
+		super()._update_attributes()
+		self._attr_changed_by = self._changed_by
+
+	def update_state(self, state: StateType) -> None:
+		if self._get_state() != state:
+			self._changed_by = self._jablotron.last_authorized_user_or_device()
+
+		super().update_state(state)
+
+	def _modify_state(self, state: AlarmControlPanelState, code: str | None) -> None:
+		self._jablotron.modify_alarm_control_panel_section_state(self._control.section, state, code)
+
+
+class JablotronCommonSegmentEntity(_JablotronAlarmControlPanelEntityBase):
+	_control: JablotronCommonSegment
+
+	def _update_attributes(self) -> None:
+		super()._update_attributes()
+		self._attr_extra_state_attributes = {
+			"sections": list(self._control.sections),
+		}
+
+	def _modify_state(self, state: AlarmControlPanelState, code: str | None) -> None:
+		self._jablotron.modify_common_segment_state(self._control, state, code)

--- a/custom_components/jablotron100/config_flow.py
+++ b/custom_components/jablotron100/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import selector
 import re
 import time
 import threading
-from typing import Any, Dict, Final, List
+from typing import Any, Dict, List
 import voluptuous as vol
 from .const import (
 	AUTODETECT_SERIAL_PORT,
@@ -37,6 +37,7 @@ from .const import (
 	DEFAULT_CONF_REQUIRE_CODE_TO_DISARM,
 	DOMAIN,
 	DeviceType,
+	EntityType,
 	LOGGER,
 	MAX_DEVICES,
 	MAX_PG_OUTPUTS,
@@ -55,7 +56,7 @@ from .errors import (
 	SerialPortNotDetected,
 	ServiceUnavailable,
 )
-from .jablotron import Jablotron
+from .jablotron import Jablotron, JablotronAlarmControlPanel
 
 
 def check_serial_port(serial_port: str) -> None:
@@ -160,22 +161,6 @@ def get_devices_fields(number_of_devices: int, default_values: List | None = Non
 
 def create_range_validation(minimum: int, maximum: int):
 	return vol.All(vol.Coerce(int), vol.Range(min=minimum, max=maximum))
-
-
-MAX_COMMON_SEGMENT_ROWS: Final = 5
-
-
-def _parse_sections_list(raw: str) -> List[int]:
-	"""Parse a comma/space separated section list. Raises ValueError on bad input."""
-	tokens = [t.strip() for t in re.split(r"[,\s]+", raw) if t.strip()]
-	sections: List[int] = []
-	for token in tokens:
-		value = int(token)
-		if value < 1 or value > MAX_SECTIONS:
-			raise ValueError(token)
-		if value not in sections:
-			sections.append(value)
-	return sections
 
 
 class JablotronConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -412,8 +397,11 @@ class JablotronConfigFlow(ConfigFlow, domain=DOMAIN):
 
 class JablotronOptionsFlow(OptionsFlow):
 	_options: Dict[str, Any]
+	_config_entry: ConfigEntry
+	_editing_segment_index: int | None = None
 
 	def __init__(self, config_entry: ConfigEntry) -> None:
+		self._config_entry = config_entry
 		self._options = deepcopy(dict(config_entry.options))
 
 	async def async_step_init(self, user_input: Dict[str, Any] | None = None) -> ConfigFlowResult:
@@ -461,82 +449,143 @@ class JablotronOptionsFlow(OptionsFlow):
 		)
 
 	async def async_step_common_segments(self, user_input: Dict[str, Any] | None = None) -> ConfigFlowResult:
-		max_rows = MAX_COMMON_SEGMENT_ROWS
-		errors: Dict[str, str] = {}
-
+		# Hub step — lists currently configured common segments and lets the
+		# user pick an action (add / edit / remove / save & exit). The actual
+		# add/edit form lives in async_step_common_segment_form, which dispatches
+		# back here on save.
 		if user_input is not None:
-			parsed: List[Dict[str, Any]] = []
-			any_invalid = False
+			action = str(user_input.get("action", ""))
 
-			for index in range(1, max_rows + 1):
-				name_field = "common_segment_name_{}".format(index)
-				sections_field = "common_segment_sections_{}".format(index)
+			if action == "add":
+				self._editing_segment_index = None
+				return await self.async_step_common_segment_form()
 
-				name = str(user_input.get(name_field, "") or "").strip()
-				sections_raw = str(user_input.get(sections_field, "") or "").strip()
-
-				if not name and not sections_raw:
-					continue
-
-				if not sections_raw:
-					errors[sections_field] = "common_segments_invalid_sections"
-					any_invalid = True
-					continue
-
-				if not name:
-					errors[name_field] = "common_segments_name_required"
-					any_invalid = True
-					continue
-
+			if action.startswith("edit_"):
 				try:
-					sections = _parse_sections_list(sections_raw)
+					self._editing_segment_index = int(action[len("edit_"):])
 				except ValueError:
-					errors[sections_field] = "common_segments_invalid_sections"
-					any_invalid = True
-					continue
+					self._editing_segment_index = None
+				return await self.async_step_common_segment_form()
 
-				if not sections:
-					errors[sections_field] = "common_segments_invalid_sections"
-					any_invalid = True
-					continue
+			if action.startswith("remove_"):
+				try:
+					index = int(action[len("remove_"):])
+				except ValueError:
+					return await self.async_step_common_segments()
+				segments = list(self._options.get(CONF_COMMON_SEGMENTS, []) or [])
+				if 0 <= index < len(segments):
+					del segments[index]
+					self._options[CONF_COMMON_SEGMENTS] = segments
+				return await self.async_step_common_segments()
 
-				parsed.append({
-					CommonSegmentData.NAME.value: name,
-					CommonSegmentData.SECTIONS.value: sections,
-				})
-
-			if not any_invalid:
-				self._options[CONF_COMMON_SEGMENTS] = parsed
+			if action == "save":
 				return self._save()
 
-		defaults: Dict[str, str] = {}
-		if user_input is not None:
-			# Preserve what the user typed on validation error.
-			for index in range(1, max_rows + 1):
-				name_field = "common_segment_name_{}".format(index)
-				sections_field = "common_segment_sections_{}".format(index)
-				defaults[name_field] = str(user_input.get(name_field, "") or "")
-				defaults[sections_field] = str(user_input.get(sections_field, "") or "")
-		else:
-			existing = self._options.get(CONF_COMMON_SEGMENTS, []) or []
-			for index in range(1, max_rows + 1):
-				row = existing[index - 1] if index - 1 < len(existing) else {}
-				name_default = str(row.get(CommonSegmentData.NAME.value, "") or "")
-				sections_value = row.get(CommonSegmentData.SECTIONS.value, []) or []
-				sections_default = ", ".join(str(s) for s in sections_value)
-				defaults["common_segment_name_{}".format(index)] = name_default
-				defaults["common_segment_sections_{}".format(index)] = sections_default
+		existing = self._options.get(CONF_COMMON_SEGMENTS, []) or []
 
-		schema_fields: Dict[Any, Any] = {}
-		for i in range(1, max_rows + 1):
-			schema_fields[vol.Optional("common_segment_name_{}".format(i), default=defaults["common_segment_name_{}".format(i)])] = str
-			schema_fields[vol.Optional("common_segment_sections_{}".format(i), default=defaults["common_segment_sections_{}".format(i)])] = str
+		options: List[Dict[str, str]] = [{"value": "add", "label": "+ Add common segment"}]
+		for i, seg in enumerate(existing):
+			name = str(seg.get(CommonSegmentData.NAME.value, "") or f"#{i + 1}")
+			sections_value = seg.get(CommonSegmentData.SECTIONS.value, []) or []
+			sections_str = ", ".join(str(s) for s in sections_value) if sections_value else "—"
+			options.append({"value": f"edit_{i}", "label": f"✎ Edit: {name} ({sections_str})"})
+			options.append({"value": f"remove_{i}", "label": f"✕ Remove: {name}"})
+		options.append({"value": "save", "label": "✓ Save and exit"})
 
 		return self.async_show_form(
 			step_id="common_segments",
-			data_schema=vol.Schema(schema_fields),
+			data_schema=vol.Schema({
+				vol.Required("action"): selector.SelectSelector(
+					selector.SelectSelectorConfig(
+						options=options,
+						mode=selector.SelectSelectorMode.LIST,
+					),
+				),
+			}),
+		)
+
+	async def async_step_common_segment_form(self, user_input: Dict[str, Any] | None = None) -> ConfigFlowResult:
+		# Add (when _editing_segment_index is None) or edit (when set) a single
+		# common segment. On save returns to the hub.
+		errors: Dict[str, str] = {}
+		existing = list(self._options.get(CONF_COMMON_SEGMENTS, []) or [])
+		editing_index = self._editing_segment_index
+		is_edit = editing_index is not None and 0 <= editing_index < len(existing)
+
+		name_default = ""
+		sections_default: List[str] = []
+
+		if is_edit:
+			seg = existing[editing_index]
+			name_default = str(seg.get(CommonSegmentData.NAME.value, "") or "")
+			sections_default = [str(s) for s in seg.get(CommonSegmentData.SECTIONS.value, []) or []]
+
+		if user_input is not None:
+			name_default = str(user_input.get("name", "") or "").strip()
+			sections_default = list(user_input.get("sections", []) or [])
+
+			try:
+				sections_int = [int(s) for s in sections_default]
+			except (ValueError, TypeError):
+				sections_int = []
+
+			if not name_default:
+				errors["name"] = "common_segments_name_required"
+			if not sections_int:
+				errors["sections"] = "common_segments_invalid_sections"
+
+			if not errors:
+				new_segment = {
+					CommonSegmentData.NAME.value: name_default,
+					CommonSegmentData.SECTIONS.value: sections_int,
+				}
+				if is_edit:
+					existing[editing_index] = new_segment
+				else:
+					existing.append(new_segment)
+				self._options[CONF_COMMON_SEGMENTS] = existing
+				self._editing_segment_index = None
+				return await self.async_step_common_segments()
+
+		section_options = self._get_section_selector_options(
+			include=[int(s) for s in sections_default if str(s).isdigit()],
+		)
+
+		return self.async_show_form(
+			step_id="common_segment_form",
+			data_schema=vol.Schema({
+				vol.Required("name", default=name_default): str,
+				vol.Required("sections", default=sections_default): selector.SelectSelector(
+					selector.SelectSelectorConfig(
+						options=section_options,
+						multiple=True,
+						mode=selector.SelectSelectorMode.LIST,
+					),
+				),
+			}),
 			errors=errors,
 		)
+
+	def _get_section_selector_options(self, include: List[int] | None = None) -> List[Dict[str, str]]:
+		# Build the dropdown of available section numbers, preferring whatever
+		# the running Jablotron instance has detected. Falls back to the full
+		# MAX_SECTIONS range if the integration is not yet loaded.
+		sections: set[int] = set()
+		try:
+			jablotron = self._config_entry.runtime_data
+			for control in jablotron.entities[EntityType.ALARM_CONTROL_PANEL].values():
+				if isinstance(control, JablotronAlarmControlPanel):
+					sections.add(control.section)
+		except (AttributeError, KeyError):
+			pass
+
+		if include:
+			sections.update(include)
+
+		if not sections:
+			sections = set(range(1, MAX_SECTIONS + 1))
+
+		return [{"value": str(s), "label": f"Section {s}"} for s in sorted(sections)]
 
 	async def async_step_debug(self, user_input: Dict[str, Any] | None = None) -> ConfigFlowResult:
 		if user_input is not None:

--- a/custom_components/jablotron100/config_flow.py
+++ b/custom_components/jablotron100/config_flow.py
@@ -11,12 +11,14 @@ from homeassistant.helpers import selector
 import re
 import time
 import threading
-from typing import Any, Dict, List
+from typing import Any, Dict, Final, List
 import voluptuous as vol
 from .const import (
 	AUTODETECT_SERIAL_PORT,
 	CODE_MAX_LENGTH,
 	CODE_MIN_LENGTH,
+	CommonSegmentData,
+	CONF_COMMON_SEGMENTS,
 	CONF_DEVICES,
 	CONF_ENABLE_DEBUGGING,
 	CONF_LOG_ALL_INCOMING_PACKETS,
@@ -38,6 +40,7 @@ from .const import (
 	LOGGER,
 	MAX_DEVICES,
 	MAX_PG_OUTPUTS,
+	MAX_SECTIONS,
 	NAME,
 	PACKET_SYSTEM_INFO,
 	PartiallyArmingMode,
@@ -157,6 +160,22 @@ def get_devices_fields(number_of_devices: int, default_values: List | None = Non
 
 def create_range_validation(minimum: int, maximum: int):
 	return vol.All(vol.Coerce(int), vol.Range(min=minimum, max=maximum))
+
+
+MAX_COMMON_SEGMENT_ROWS: Final = 5
+
+
+def _parse_sections_list(raw: str) -> List[int]:
+	"""Parse a comma/space separated section list. Raises ValueError on bad input."""
+	tokens = [t.strip() for t in re.split(r"[,\s]+", raw) if t.strip()]
+	sections: List[int] = []
+	for token in tokens:
+		value = int(token)
+		if value < 1 or value > MAX_SECTIONS:
+			raise ValueError(token)
+		if value not in sections:
+			sections.append(value)
+	return sections
 
 
 class JablotronConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -400,7 +419,7 @@ class JablotronOptionsFlow(OptionsFlow):
 	async def async_step_init(self, user_input: Dict[str, Any] | None = None) -> ConfigFlowResult:
 		return self.async_show_menu(
 			step_id="init",
-			menu_options=["options", "debug"],
+			menu_options=["options", "common_segments", "debug"],
 		)
 
 	async def async_step_options(self, user_input: Dict[str, Any] | None = None) -> ConfigFlowResult:
@@ -439,6 +458,84 @@ class JablotronOptionsFlow(OptionsFlow):
 					): bool,
 				}
 			),
+		)
+
+	async def async_step_common_segments(self, user_input: Dict[str, Any] | None = None) -> ConfigFlowResult:
+		max_rows = MAX_COMMON_SEGMENT_ROWS
+		errors: Dict[str, str] = {}
+
+		if user_input is not None:
+			parsed: List[Dict[str, Any]] = []
+			any_invalid = False
+
+			for index in range(1, max_rows + 1):
+				name_field = "common_segment_name_{}".format(index)
+				sections_field = "common_segment_sections_{}".format(index)
+
+				name = str(user_input.get(name_field, "") or "").strip()
+				sections_raw = str(user_input.get(sections_field, "") or "").strip()
+
+				if not name and not sections_raw:
+					continue
+
+				if not sections_raw:
+					errors[sections_field] = "common_segments_invalid_sections"
+					any_invalid = True
+					continue
+
+				if not name:
+					errors[name_field] = "common_segments_name_required"
+					any_invalid = True
+					continue
+
+				try:
+					sections = _parse_sections_list(sections_raw)
+				except ValueError:
+					errors[sections_field] = "common_segments_invalid_sections"
+					any_invalid = True
+					continue
+
+				if not sections:
+					errors[sections_field] = "common_segments_invalid_sections"
+					any_invalid = True
+					continue
+
+				parsed.append({
+					CommonSegmentData.NAME.value: name,
+					CommonSegmentData.SECTIONS.value: sections,
+				})
+
+			if not any_invalid:
+				self._options[CONF_COMMON_SEGMENTS] = parsed
+				return self._save()
+
+		defaults: Dict[str, str] = {}
+		if user_input is not None:
+			# Preserve what the user typed on validation error.
+			for index in range(1, max_rows + 1):
+				name_field = "common_segment_name_{}".format(index)
+				sections_field = "common_segment_sections_{}".format(index)
+				defaults[name_field] = str(user_input.get(name_field, "") or "")
+				defaults[sections_field] = str(user_input.get(sections_field, "") or "")
+		else:
+			existing = self._options.get(CONF_COMMON_SEGMENTS, []) or []
+			for index in range(1, max_rows + 1):
+				row = existing[index - 1] if index - 1 < len(existing) else {}
+				name_default = str(row.get(CommonSegmentData.NAME.value, "") or "")
+				sections_value = row.get(CommonSegmentData.SECTIONS.value, []) or []
+				sections_default = ", ".join(str(s) for s in sections_value)
+				defaults["common_segment_name_{}".format(index)] = name_default
+				defaults["common_segment_sections_{}".format(index)] = sections_default
+
+		schema_fields: Dict[Any, Any] = {}
+		for i in range(1, max_rows + 1):
+			schema_fields[vol.Optional("common_segment_name_{}".format(i), default=defaults["common_segment_name_{}".format(i)])] = str
+			schema_fields[vol.Optional("common_segment_sections_{}".format(i), default=defaults["common_segment_sections_{}".format(i)])] = str
+
+		return self.async_show_form(
+			step_id="common_segments",
+			data_schema=vol.Schema(schema_fields),
+			errors=errors,
 		)
 
 	async def async_step_debug(self, user_input: Dict[str, Any] | None = None) -> ConfigFlowResult:

--- a/custom_components/jablotron100/const.py
+++ b/custom_components/jablotron100/const.py
@@ -21,6 +21,12 @@ CONF_REQUIRE_CODE_TO_ARM: Final = "require_code_to_arm"
 CONF_REQUIRE_CODE_TO_DISARM: Final = "require_code_to_disarm"
 CONF_PARTIALLY_ARMING_MODE: Final = "partially_arming_mode"
 CONF_ENABLE_DEBUGGING: Final = "enable_debugging"
+CONF_COMMON_SEGMENTS: Final = "common_segments"
+
+
+class CommonSegmentData(StrEnum):
+	NAME = "name"
+	SECTIONS = "sections"
 
 CONF_LOG_ALL_INCOMING_PACKETS: Final = "log_all_incoming_packets"
 CONF_LOG_ALL_OUTCOMING_PACKETS: Final = "log_all_outcoming_packets"

--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -33,10 +33,12 @@ from .const import (
 	CentralUnitData,
 	CODE_MIN_LENGTH,
 	COMMAND_ENABLE_DEVICE_STATE_PACKETS,
+	CommonSegmentData,
 	COMMAND_GET_DEVICE_STATUS,
 	COMMAND_GET_SECTIONS_AND_PG_OUTPUTS_STATES,
 	COMMAND_HEARTBEAT,
 	COMMAND_RESPONSE_DEVICE_STATUS,
+	CONF_COMMON_SEGMENTS,
 	CONF_DEVICES,
 	CONF_ENABLE_DEBUGGING,
 	CONF_LOG_ALL_INCOMING_PACKETS,
@@ -194,6 +196,14 @@ class JablotronAlarmControlPanel(JablotronControl):
 		super().__init__(central_unit, hass_device, panel_id)
 
 
+class JablotronCommonSegment(JablotronControl):
+
+	def __init__(self, central_unit: JablotronCentralUnit, hass_device: JablotronHassDevice, panel_id: str, name: str, sections: List[int]) -> None:
+		self.sections: List[int] = sections
+
+		super().__init__(central_unit, hass_device, panel_id, name)
+
+
 class JablotronProgrammableOutput(JablotronControl):
 
 	def __init__(self, central_unit: JablotronCentralUnit, pg_output_id: str, pg_output_name: str, pg_output_number: int) -> None:
@@ -316,6 +326,7 @@ class Jablotron:
 		await self._create_devices()
 		# We need to detect devices first
 		self._detect_sections_and_pg_outputs()
+		self._create_common_segments()
 
 	def central_unit(self) -> JablotronCentralUnit:
 		return self._central_unit
@@ -338,6 +349,25 @@ class Jablotron:
 		self.hass_entities[control_id] = hass_entity
 
 	def modify_alarm_control_panel_section_state(self, section: int, state: AlarmControlPanelState, code: str | None) -> None:
+		self._modify_alarm_control_panel_sections_state([section], state, code)
+
+	def modify_common_segment_state(self, common_segment: JablotronCommonSegment, state: AlarmControlPanelState, code: str | None) -> None:
+		# Filter to sections that actually exist on the panel.
+		valid_sections = [
+			section
+			for section in common_segment.sections
+			if self._get_section_alarm_id(section) in self.entities[EntityType.ALARM_CONTROL_PANEL]
+		]
+
+		if not valid_sections:
+			return
+
+		self._modify_alarm_control_panel_sections_state(valid_sections, state, code)
+
+	def _modify_alarm_control_panel_sections_state(self, sections: List[int], state: AlarmControlPanelState, code: str | None) -> None:
+		if not sections:
+			return
+
 		if code is None:
 			code = self._config[CONF_PASSWORD]
 
@@ -369,8 +399,9 @@ class Jablotron:
 			packets_to_send: List[bytes] = []
 
 			if self._successful_login is True:
-				modify_packet = self.int_to_bytes(int_packets[state] + section)
-				packets_to_send.append(self.create_packet_ui_control(UI_CONTROL_MODIFY_SECTION, modify_packet))
+				for section in sections:
+					modify_packet = self.int_to_bytes(int_packets[state] + section)
+					packets_to_send.append(self.create_packet_ui_control(UI_CONTROL_MODIFY_SECTION, modify_packet))
 
 			if code != self._config[CONF_PASSWORD]:
 				packets_to_send.append(self.create_packet_ui_control(UI_CONTROL_AUTHORISATION_END))
@@ -624,6 +655,90 @@ class Jablotron:
 			)
 
 		return True
+
+	def _create_common_segments(self) -> None:
+		for index, common_segment_config in enumerate(self._get_common_segments_config()):
+			name = str(common_segment_config.get(CommonSegmentData.NAME.value, "") or "").strip()
+			sections = [int(s) for s in common_segment_config.get(CommonSegmentData.SECTIONS.value, [])]
+
+			if not name or not sections:
+				continue
+
+			common_segment_id = self._get_common_segment_id(index)
+			common_segment_hass_device = self._create_common_segment_hass_device(index, name)
+
+			self.entities[EntityType.ALARM_CONTROL_PANEL][common_segment_id] = JablotronCommonSegment(
+				self._central_unit,
+				common_segment_hass_device,
+				common_segment_id,
+				name,
+				sections,
+			)
+
+			initial_state = self._derive_common_segment_alarm_state(sections)
+			self._set_entity_initial_state(common_segment_id, initial_state)
+
+	def _get_common_segments_config(self) -> List[Dict[str, Any]]:
+		raw = self._options.get(CONF_COMMON_SEGMENTS, [])
+		if not isinstance(raw, list):
+			return []
+		return raw
+
+	def _derive_common_segment_alarm_state(self, sections: List[int]) -> AlarmControlPanelState | None:
+		states: List[AlarmControlPanelState] = []
+		for section in sections:
+			section_id = self._get_section_alarm_id(section)
+			section_state = self.entities_states.get(section_id)
+			if section_state is None:
+				continue
+			states.append(section_state)
+
+		if not states:
+			return None
+
+		# TRIGGERED and PENDING are urgent states that should bubble up to the
+		# common segment regardless of other sections — the alarm is going off
+		# / about to go off and the user needs to see it on the aggregate entity.
+		if AlarmControlPanelState.TRIGGERED in states:
+			return AlarmControlPanelState.TRIGGERED
+		if AlarmControlPanelState.PENDING in states:
+			return AlarmControlPanelState.PENDING
+
+		# A common segment is "armed" (or "arming") only when every constituent
+		# section is at least beyond DISARMED. Without this check, arming a
+		# single section with delayed arming would flip the whole common segment
+		# into ARMING even though the rest of the house stays disarmed.
+		if AlarmControlPanelState.DISARMED in states:
+			return AlarmControlPanelState.DISARMED
+
+		if AlarmControlPanelState.ARMING in states:
+			return AlarmControlPanelState.ARMING
+
+		# Pick the lowest common armed level so any mixed armed states still report
+		# the segment as armed (just not at the strictest level).
+		level: AlarmControlPanelState | None = None
+		for state in states:
+			if state == AlarmControlPanelState.ARMED_AWAY:
+				if level is None:
+					level = AlarmControlPanelState.ARMED_AWAY
+				continue
+			if state in (AlarmControlPanelState.ARMED_HOME, AlarmControlPanelState.ARMED_NIGHT):
+				level = state
+				continue
+			# Anything else (e.g. None or unexpected) — treat as not armed.
+			return AlarmControlPanelState.DISARMED
+
+		return level if level is not None else AlarmControlPanelState.DISARMED
+
+	def _refresh_common_segments_states(self) -> None:
+		for common_segment_id, control in self.entities[EntityType.ALARM_CONTROL_PANEL].items():
+			if not isinstance(control, JablotronCommonSegment):
+				continue
+			self._update_entity_state(
+				common_segment_id,
+				self._derive_common_segment_alarm_state(control.sections),
+				store_state=False,
+			)
 
 	def _create_pg_outputs(self) -> None:
 		if not self._has_pg_outputs():
@@ -1256,6 +1371,8 @@ class Jablotron:
 					self._convert_jablotron_section_state_to_fire_sensor_state(section_state),
 					store_state=False,
 				)
+
+		self._refresh_common_segments_states()
 
 		# No service mode found
 		self.in_service_mode = False
@@ -2484,6 +2601,19 @@ class Jablotron:
 			"section",
 			{"sectionNo": section},
 		)
+
+	@staticmethod
+	def _create_common_segment_hass_device(index: int, name: str) -> JablotronHassDevice:
+		return JablotronHassDevice(
+			"common_segment_{}".format(index),
+			name,
+			"common_segment",
+			{"name": name},
+		)
+
+	@staticmethod
+	def _get_common_segment_id(index: int) -> str:
+		return "common_segment_{}".format(index)
 
 	@staticmethod
 	def _get_section_alarm_id(section: int) -> str:

--- a/custom_components/jablotron100/strings.json
+++ b/custom_components/jablotron100/strings.json
@@ -508,6 +508,7 @@
 			"init": {
 				"menu_options": {
 					"options": "Options",
+					"common_segments": "Common segments",
 					"debug": "Debugging"
 				}
 			},
@@ -517,6 +518,22 @@
 					"partially_arming_mode": "Partially arming",
 					"require_code_to_arm": "Require code to arm",
 					"require_code_to_disarm": "Require code to disarm"
+				}
+			},
+			"common_segments": {
+				"title": "Common segments",
+				"description": "Define virtual common segments that arm/disarm multiple sections with a single command. Specify a name and a comma-separated list of section numbers (e.g. \"1, 2, 3\"). Empty rows are ignored.",
+				"data": {
+					"common_segment_name_1": "Name 1",
+					"common_segment_sections_1": "Sections 1",
+					"common_segment_name_2": "Name 2",
+					"common_segment_sections_2": "Sections 2",
+					"common_segment_name_3": "Name 3",
+					"common_segment_sections_3": "Sections 3",
+					"common_segment_name_4": "Name 4",
+					"common_segment_sections_4": "Sections 4",
+					"common_segment_name_5": "Name 5",
+					"common_segment_sections_5": "Sections 5"
 				}
 			},
 			"debug": {
@@ -529,6 +546,10 @@
 					"log_pg_outputs_packets": "Log PG outputs packets"
 				}
 			}
+		},
+		"error": {
+			"common_segments_invalid_sections": "Sections must be a comma-separated list of section numbers (e.g. \"1, 2, 3\").",
+			"common_segments_name_required": "Name is required when sections are provided."
 		}
 	},
 	"selector": {
@@ -643,6 +664,9 @@
 		},
 		"section": {
 			"name": "Section {sectionNo}"
+		},
+		"common_segment": {
+			"name": "{name}"
 		}
 	},
 	"entity": {

--- a/custom_components/jablotron100/strings.json
+++ b/custom_components/jablotron100/strings.json
@@ -522,18 +522,17 @@
 			},
 			"common_segments": {
 				"title": "Common segments",
-				"description": "Define virtual common segments that arm/disarm multiple sections with a single command. Specify a name and a comma-separated list of section numbers (e.g. \"1, 2, 3\"). Empty rows are ignored.",
+				"description": "Manage virtual common segments that arm/disarm multiple sections with a single command. Pick an action below.",
 				"data": {
-					"common_segment_name_1": "Name 1",
-					"common_segment_sections_1": "Sections 1",
-					"common_segment_name_2": "Name 2",
-					"common_segment_sections_2": "Sections 2",
-					"common_segment_name_3": "Name 3",
-					"common_segment_sections_3": "Sections 3",
-					"common_segment_name_4": "Name 4",
-					"common_segment_sections_4": "Sections 4",
-					"common_segment_name_5": "Name 5",
-					"common_segment_sections_5": "Sections 5"
+					"action": "Action"
+				}
+			},
+			"common_segment_form": {
+				"title": "Common segment",
+				"description": "Name the segment and pick which physical sections it controls.",
+				"data": {
+					"name": "Name",
+					"sections": "Sections"
 				}
 			},
 			"debug": {

--- a/custom_components/jablotron100/translations/cs.json
+++ b/custom_components/jablotron100/translations/cs.json
@@ -508,6 +508,7 @@
 			"init": {
 				"menu_options": {
 					"options": "Možnosti",
+					"common_segments": "Společné segmenty",
 					"debug": "Ladění"
 				}
 			},
@@ -517,6 +518,22 @@
 					"partially_arming_mode": "Částečné zabezpečení",
 					"require_code_to_arm": "Vyžadovat kód k zabezpečení",
 					"require_code_to_disarm": "Vyžadovat kód k odbezpečení"
+				}
+			},
+			"common_segments": {
+				"title": "Společné segmenty",
+				"description": "Definujte virtuální společné segmenty, které jedním příkazem zabezpečí nebo odbezpečí více sekcí. Zadejte název a seznam čísel sekcí oddělených čárkou (např. \"1, 2, 3\"). Prázdné řádky se ignorují.",
+				"data": {
+					"common_segment_name_1": "Název 1",
+					"common_segment_sections_1": "Sekce 1",
+					"common_segment_name_2": "Název 2",
+					"common_segment_sections_2": "Sekce 2",
+					"common_segment_name_3": "Název 3",
+					"common_segment_sections_3": "Sekce 3",
+					"common_segment_name_4": "Název 4",
+					"common_segment_sections_4": "Sekce 4",
+					"common_segment_name_5": "Název 5",
+					"common_segment_sections_5": "Sekce 5"
 				}
 			},
 			"debug": {
@@ -529,6 +546,10 @@
 					"log_pg_outputs_packets": "Logovat pakety programovatelných výstupů PG"
 				}
 			}
+		},
+		"error": {
+			"common_segments_invalid_sections": "Sekce musí být seznam čísel sekcí oddělený čárkou (např. \"1, 2, 3\").",
+			"common_segments_name_required": "Při zadaných sekcích je název povinný."
 		}
 	},
 	"selector": {
@@ -643,6 +664,9 @@
 		},
 		"section": {
 			"name": "Sekce {sectionNo}"
+		},
+		"common_segment": {
+			"name": "{name}"
 		}
 	},
 	"entity": {

--- a/custom_components/jablotron100/translations/cs.json
+++ b/custom_components/jablotron100/translations/cs.json
@@ -522,18 +522,17 @@
 			},
 			"common_segments": {
 				"title": "Společné segmenty",
-				"description": "Definujte virtuální společné segmenty, které jedním příkazem zabezpečí nebo odbezpečí více sekcí. Zadejte název a seznam čísel sekcí oddělených čárkou (např. \"1, 2, 3\"). Prázdné řádky se ignorují.",
+				"description": "Spravuj virtuální společné segmenty, které jedním příkazem zabezpečí nebo odbezpečí více sekcí. Vyber akci níže.",
 				"data": {
-					"common_segment_name_1": "Název 1",
-					"common_segment_sections_1": "Sekce 1",
-					"common_segment_name_2": "Název 2",
-					"common_segment_sections_2": "Sekce 2",
-					"common_segment_name_3": "Název 3",
-					"common_segment_sections_3": "Sekce 3",
-					"common_segment_name_4": "Název 4",
-					"common_segment_sections_4": "Sekce 4",
-					"common_segment_name_5": "Název 5",
-					"common_segment_sections_5": "Sekce 5"
+					"action": "Akce"
+				}
+			},
+			"common_segment_form": {
+				"title": "Společný segment",
+				"description": "Pojmenuj segment a vyber které fyzické sekce ovládá.",
+				"data": {
+					"name": "Název",
+					"sections": "Sekce"
 				}
 			},
 			"debug": {

--- a/custom_components/jablotron100/translations/en.json
+++ b/custom_components/jablotron100/translations/en.json
@@ -508,6 +508,7 @@
 			"init": {
 				"menu_options": {
 					"options": "Options",
+					"common_segments": "Common segments",
 					"debug": "Debugging"
 				}
 			},
@@ -517,6 +518,22 @@
 					"partially_arming_mode": "Partially arming",
 					"require_code_to_arm": "Require code to arm",
 					"require_code_to_disarm": "Require code to disarm"
+				}
+			},
+			"common_segments": {
+				"title": "Common segments",
+				"description": "Define virtual common segments that arm/disarm multiple sections with a single command. Specify a name and a comma-separated list of section numbers (e.g. \"1, 2, 3\"). Empty rows are ignored.",
+				"data": {
+					"common_segment_name_1": "Name 1",
+					"common_segment_sections_1": "Sections 1",
+					"common_segment_name_2": "Name 2",
+					"common_segment_sections_2": "Sections 2",
+					"common_segment_name_3": "Name 3",
+					"common_segment_sections_3": "Sections 3",
+					"common_segment_name_4": "Name 4",
+					"common_segment_sections_4": "Sections 4",
+					"common_segment_name_5": "Name 5",
+					"common_segment_sections_5": "Sections 5"
 				}
 			},
 			"debug": {
@@ -529,6 +546,10 @@
 					"log_pg_outputs_packets": "Log PG outputs packets"
 				}
 			}
+		},
+		"error": {
+			"common_segments_invalid_sections": "Sections must be a comma-separated list of section numbers (e.g. \"1, 2, 3\").",
+			"common_segments_name_required": "Name is required when sections are provided."
 		}
 	},
 	"selector": {
@@ -643,6 +664,9 @@
 		},
 		"section": {
 			"name": "Section {sectionNo}"
+		},
+		"common_segment": {
+			"name": "{name}"
 		}
 	},
 	"entity": {

--- a/custom_components/jablotron100/translations/en.json
+++ b/custom_components/jablotron100/translations/en.json
@@ -522,18 +522,17 @@
 			},
 			"common_segments": {
 				"title": "Common segments",
-				"description": "Define virtual common segments that arm/disarm multiple sections with a single command. Specify a name and a comma-separated list of section numbers (e.g. \"1, 2, 3\"). Empty rows are ignored.",
+				"description": "Manage virtual common segments that arm/disarm multiple sections with a single command. Pick an action below.",
 				"data": {
-					"common_segment_name_1": "Name 1",
-					"common_segment_sections_1": "Sections 1",
-					"common_segment_name_2": "Name 2",
-					"common_segment_sections_2": "Sections 2",
-					"common_segment_name_3": "Name 3",
-					"common_segment_sections_3": "Sections 3",
-					"common_segment_name_4": "Name 4",
-					"common_segment_sections_4": "Sections 4",
-					"common_segment_name_5": "Name 5",
-					"common_segment_sections_5": "Sections 5"
+					"action": "Action"
+				}
+			},
+			"common_segment_form": {
+				"title": "Common segment",
+				"description": "Name the segment and pick which physical sections it controls.",
+				"data": {
+					"name": "Name",
+					"sections": "Sections"
 				}
 			},
 			"debug": {

--- a/custom_components/jablotron100/translations/sk.json
+++ b/custom_components/jablotron100/translations/sk.json
@@ -522,18 +522,17 @@
 			},
 			"common_segments": {
 				"title": "Spoločné segmenty",
-				"description": "Definujte virtuálne spoločné segmenty, ktoré jedným príkazom zabezpečia alebo odbezpečia viacero sekcií. Zadajte názov a zoznam čísel sekcií oddelených čiarkou (napr. \"1, 2, 3\"). Prázdne riadky sa ignorujú.",
+				"description": "Spravuj virtuálne spoločné segmenty, ktoré jedným príkazom zabezpečia alebo odbezpečia viacero sekcií. Vyber akciu nižšie.",
 				"data": {
-					"common_segment_name_1": "Názov 1",
-					"common_segment_sections_1": "Sekcie 1",
-					"common_segment_name_2": "Názov 2",
-					"common_segment_sections_2": "Sekcie 2",
-					"common_segment_name_3": "Názov 3",
-					"common_segment_sections_3": "Sekcie 3",
-					"common_segment_name_4": "Názov 4",
-					"common_segment_sections_4": "Sekcie 4",
-					"common_segment_name_5": "Názov 5",
-					"common_segment_sections_5": "Sekcie 5"
+					"action": "Akcia"
+				}
+			},
+			"common_segment_form": {
+				"title": "Spoločný segment",
+				"description": "Pomenuj segment a vyber ktoré fyzické sekcie ovláda.",
+				"data": {
+					"name": "Názov",
+					"sections": "Sekcie"
 				}
 			},
 			"debug": {

--- a/custom_components/jablotron100/translations/sk.json
+++ b/custom_components/jablotron100/translations/sk.json
@@ -508,6 +508,7 @@
 			"init": {
 				"menu_options": {
 					"options": "Možnosti",
+					"common_segments": "Spoločné segmenty",
 					"debug": "Ladenie"
 				}
 			},
@@ -517,6 +518,22 @@
 					"partially_arming_mode": "Partially arming",
 					"require_code_to_arm": "Vyžadovať kód k zabezpečeniu",
 					"require_code_to_disarm": "Vyžadovať kód k odbezpečeniu"
+				}
+			},
+			"common_segments": {
+				"title": "Spoločné segmenty",
+				"description": "Definujte virtuálne spoločné segmenty, ktoré jedným príkazom zabezpečia alebo odbezpečia viacero sekcií. Zadajte názov a zoznam čísel sekcií oddelených čiarkou (napr. \"1, 2, 3\"). Prázdne riadky sa ignorujú.",
+				"data": {
+					"common_segment_name_1": "Názov 1",
+					"common_segment_sections_1": "Sekcie 1",
+					"common_segment_name_2": "Názov 2",
+					"common_segment_sections_2": "Sekcie 2",
+					"common_segment_name_3": "Názov 3",
+					"common_segment_sections_3": "Sekcie 3",
+					"common_segment_name_4": "Názov 4",
+					"common_segment_sections_4": "Sekcie 4",
+					"common_segment_name_5": "Názov 5",
+					"common_segment_sections_5": "Sekcie 5"
 				}
 			},
 			"debug": {
@@ -529,6 +546,10 @@
 					"log_pg_outputs_packets": "Logovať pakety programovateľných výstupov PG"
 				}
 			}
+		},
+		"error": {
+			"common_segments_invalid_sections": "Sekcie musia byť zoznam čísel sekcií oddelený čiarkou (napr. \"1, 2, 3\").",
+			"common_segments_name_required": "Pri zadaných sekciách je názov povinný."
 		}
 	},
 	"selector": {
@@ -643,6 +664,9 @@
 		},
 		"section": {
 			"name": "Section {sectionNo}"
+		},
+		"common_segment": {
+			"name": "{name}"
 		}
 	},
 	"entity": {


### PR DESCRIPTION
Follow-up to the previous common segments PR. Replaces the fixed 5-row text form with a menu-driven flow and a real multi-select for sections.

  ## Before

  A 5-row form that always showed 5 empty rows even if you only wanted one segment. The sections column was a free-form text field where you had to type `1, 2, 3` and hope you got the format right.

  ## After
  
  **Hub step** — lists currently configured segments and lets you pick an action:
  - `+ Add common segment`
  - `✎ Edit: <name> (1, 2, 3)` per existing segment
  - `✕ Remove: <name>` per existing segment
  - `✓ Save and exit`

  **Per-segment form** — opens when you click Add or Edit:
  - `Name` — text field
  - `Sections` — multi-select list populated from the **sections the panel actually has**. The integration reads them from the running Jablotron instance via `config_entry.runtime_data`. Falls back to the full `MAX_SECTIONS` range if the
   integration is not yet loaded. Currently configured section numbers are always included even if the panel reports them as off so re-editing does not silently drop them.

  All changes are accumulated in `self._options` and only persisted when the user picks `Save and exit` — standard HA semantics, browser back / closing the dialog discards.

  ## Implementation notes
  
  - Drops `MAX_COMMON_SEGMENT_ROWS` cap (no longer needed — flow grows organically) and the comma-parser helper (`_parse_sections_list`).
  - The hub uses one form step with an action `SelectSelector` in LIST mode. The per-segment form is a second step. Dispatch happens via the action string (`add`, `edit_<i>`, `remove_<i>`, `save`) so we avoid declaring N per-index step
  methods.
  - Editing index is held in `self._editing_segment_index` between the hub dispatch and the form step. Reset on save and on "add".
  - Translations updated for en / cs / sk. The dynamic part of the menu labels (`Edit: <name> (1, 2, 3)`) stays in English because the section name comes from user input and HA selectors do not support per-option `translation_key` for
  runtime-built option lists.

  ## Test plan
  
  - [ ] Open *Configure → Common segments* with no segments configured → only `Add` and `Save and exit` visible.
  - [ ] Add a segment, return to hub, see it listed with Edit/Remove.
  - [ ] Edit, change sections, save → hub reflects new section list.
  - [ ] Remove → segment disappears from the hub immediately (still in-memory until Save).
  - [ ] Save and exit → integration reloads, configured segments appear as `alarm_control_panel` entities with the chosen sections.
  - [ ] Cancel by closing dialog → unsaved adds/edits/removes are discarded (existing entry untouched).
  - [ ] Open form with `runtime_data` temporarily missing (e.g. during reload) → sections dropdown falls back to 1..15 instead of crashing.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
