### PR TITLE
Auto-recover serial port and stream on USB re-enumeration

### DIFF
--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -1014,7 +1014,11 @@ class Jablotron:
 		self._update_all_hass_entities()
 
 	def _read_packets(self) -> None:
-		stream = self._open_read_stream()
+		try:
+			stream = self._open_read_stream()
+		except OSError as ex:
+			LOGGER.warning("Initial read stream open failed: %s", ex)
+			stream = None
 		last_restarted_at_hour = datetime.datetime.now().hour
 		consecutive_errors = 0
 
@@ -1026,6 +1030,10 @@ class Jablotron:
 					stream = self._open_read_stream()
 
 				while True:
+
+					if stream is None:
+						stream = self._open_read_stream()
+						LOGGER.warning("Read stream reopened on %s", self._serial_port)
 
 					actual_hour = datetime.datetime.now().hour
 					if last_restarted_at_hour != actual_hour:
@@ -1041,6 +1049,11 @@ class Jablotron:
 
 					if not raw_packet:
 						self._set_unavailable()
+						try:
+							stream.close()
+						except Exception:
+							pass
+						stream = None
 						break
 
 					if self.last_update_success is False:


### PR DESCRIPTION
## Problem

When the USB-HID device is re-enumerated at runtime (USB reset, suspend/resume, hub power glitch) the hidraw device number can change, e.g. `/dev/hidraw0` becomes `/dev/hidraw1`. Until now:

* the read loop in `_read_packets` kept calling `stream.read()` on the now-dead file object,
* the write loop kept opening the original, now-missing path in `_send_packet_by_stream`,

both producing an infinite stream of `[Errno 2] No such file or directory`, `[Errno 30] Read-only file system` and `[Errno 5] I/O error` log entries (tens of thousands per night in my case) until the user manually clicked **Reload** on the integration. Only the reload helped because `initialize()` re-runs autodetection by USB VID/PID.

## Fix

* `_open_read_stream` / `_open_write_stream` now catch `OSError`, run `detect_serial_port()` (autodetect by USB VID/PID `16D6:0008`) and transparently switch `self._serial_port` to the new hidraw path before retrying once. This mirrors the existing one-shot fallback in `initialize()` and works regardless of whether the user picked **auto** or a fixed path in the config.
* `_read_packets` closes the dead stream on exception (and on EOF) and reopens it on the next iteration instead of looping forever on a stale file handle.

The write loop (`_keepalive` -> `_send_packet_by_stream`) already opens a fresh handle per send, so it benefits automatically from the resilient `_open_write_stream`.

## Expected log behavior after the fix

Instead of an infinite flood of identical errors:

```n
Read error: [Errno 5] I/O error
Serial port changed from /dev/hidraw0 to /dev/hidraw1, switching
Read stream reopened on /dev/hidraw1
```

Entities go briefly unavailable and recover by themselves, no manual reload needed.