### PR TITLE
Require Home Assistant 2026.7

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,7 +3,7 @@
 	"content_in_root": false,
 	"domains": ["alarm_control_panel", "binary_sensor", "event", "sensor", "switch"],
 	"country": ["CS", "DA", "DE", "EN", "IT", "NB", "NL", "SK"],
-	"homeassistant": "2024.12.0",
+	"homeassistant": "2026.7.0",
 	"render_readme": true
 }
 


### PR DESCRIPTION
## Summary

- set the minimum supported Home Assistant version in HACS metadata to 2026.7.0

## Context

Jablotron 100 version 3.33.1 started using `UnitOfRatio.PERCENTAGE`, which is available from Home Assistant 2026.7. On Home Assistant 2026.6, the sensor platform therefore fails during import before integration setup can complete.

Declaring Home Assistant 2026.7.0 as the minimum prevents HACS from offering an incompatible integration version to older Home Assistant installations.

Closes #154

## Validation

- `hacs.json` parses successfully
- the final diff contains only the minimum-version metadata change
