### PR TITLE
Validate codes and serialize alarm authorisation

### DIFF
--- a/custom_components/jablotron100/code.py
+++ b/custom_components/jablotron100/code.py
@@ -1,0 +1,7 @@
+import re
+
+
+def validate_authorisation_code(code: str) -> str:
+	if not isinstance(code, str) or re.fullmatch(r"(?:[0-9]{4,8}|[0-9]{1,3}\*[0-9]{4,6})", code) is None:
+		raise ValueError("Invalid authorisation code")
+	return code

--- a/custom_components/jablotron100/config_flow.py
+++ b/custom_components/jablotron100/config_flow.py
@@ -13,10 +13,9 @@ import time
 import threading
 from typing import Any, Dict, List
 import voluptuous as vol
+from .code import validate_authorisation_code
 from .const import (
 	AUTODETECT_SERIAL_PORT,
-	CODE_MAX_LENGTH,
-	CODE_MIN_LENGTH,
 	CONF_DEVICES,
 	CONF_ENABLE_DEBUGGING,
 	CONF_LOG_ALL_INCOMING_PACKETS,
@@ -234,7 +233,7 @@ class JablotronConfigFlow(ConfigFlow, domain=DOMAIN):
 			data_schema=vol.Schema(
 				{
 					vol.Required(CONF_SERIAL_PORT, default=AUTODETECT_SERIAL_PORT): str,
-					vol.Required(CONF_PASSWORD): vol.All(str, vol.Length(min=CODE_MIN_LENGTH, max=CODE_MAX_LENGTH)),
+					vol.Required(CONF_PASSWORD): vol.All(str, validate_authorisation_code),
 					vol.Optional(CONF_NUMBER_OF_DEVICES, default=0): create_range_validation(0, MAX_DEVICES),
 					vol.Optional(CONF_NUMBER_OF_PG_OUTPUTS, default=0): create_range_validation(0, MAX_PG_OUTPUTS),
 				}
@@ -341,7 +340,7 @@ class JablotronConfigFlow(ConfigFlow, domain=DOMAIN):
 			vol.Optional(
 				CONF_PASSWORD,
 				default="",
-			): vol.All(str, vol.Length(min=0, max=CODE_MAX_LENGTH)),
+			): vol.Any("", vol.All(str, validate_authorisation_code)),
 		}
 
 		number_of_devices_validation = create_range_validation(self._config[CONF_NUMBER_OF_DEVICES], MAX_DEVICES)

--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -24,6 +24,7 @@ import math
 import os
 import threading
 import time
+from .code import validate_authorisation_code
 from .const import (
 	AUTODETECT_SERIAL_PORT,
 	BATTERY_LEVEL_NO_BATTERY,
@@ -31,7 +32,6 @@ from .const import (
 	BATTERY_LEVELS_TO_IGNORE,
 	BATTERY_LEVEL_STEP,
 	CentralUnitData,
-	CODE_MIN_LENGTH,
 	COMMAND_ENABLE_DEVICE_STATE_PACKETS,
 	COMMAND_GET_DEVICE_STATUS,
 	COMMAND_GET_SECTIONS_AND_PG_OUTPUTS_STATES,
@@ -361,10 +361,11 @@ class Jablotron:
 
 		code = configured_code if entered_code is None else entered_code
 
-		if len(code) < CODE_MIN_LENGTH:
+		try:
+			validate_authorisation_code(code)
+			validate_authorisation_code(configured_code)
+		except ValueError:
 			self._login_error()
-			# Update section states to have actual states
-			self._send_packet(self.create_packet_command(COMMAND_GET_SECTIONS_AND_PG_OUTPUTS_STATES))
 			return
 
 		int_packets = {
@@ -2876,6 +2877,7 @@ class Jablotron:
 
 	@staticmethod
 	def create_packet_authorisation_code(code: str) -> bytes:
+		validate_authorisation_code(code)
 		magic_offset = 48
 
 		if code.find("*") != -1:

--- a/custom_components/jablotron100/jablotron.py
+++ b/custom_components/jablotron100/jablotron.py
@@ -251,7 +251,9 @@ class Jablotron:
 		self.in_service_mode = False
 
 		self._last_authorized_user_or_device: str | None = None
-		self._successful_login: bool = True
+		self._authorisation_lock = threading.Lock()
+		self._login_failed = threading.Event()
+		self._authorisation_restore_pending = False
 
 	def signal_entities_added(self) -> str:
 		return "{}_{}_entities_added".format(DOMAIN, self._config_entry_id)
@@ -375,53 +377,40 @@ class Jablotron:
 			AlarmControlPanelState.ARMED_NIGHT: 175,
 		}
 
-		# Reset
-		self._successful_login = True
+		with self._authorisation_lock:
+			if self._stream_stop_event.is_set():
+				return
 
-		@core.callback
-		def after_modify_callback(_: datetime.datetime) -> None:
-			# Runs on the event loop; offload the blocking serial I/O.
-			self._hass.async_add_executor_job(
-				self._send_packet,
-				self.create_packet_command(COMMAND_GET_SECTIONS_AND_PG_OUTPUTS_STATES),
-			)
+			self._login_failed.clear()
+			self._authorisation_restore_pending = True
+			try:
+				self._send_packets([
+					self.create_packet_ui_control(UI_CONTROL_AUTHORISATION_END),
+					self.create_packet_authorisation_code(code),
+				])
+				if self._stream_stop_event.wait(1.0):
+					return
 
-		@core.callback
-		def after_login_callback(_: datetime.datetime | None) -> None:
-			# Runs on the event loop; offload the blocking serial I/O.
-			packets_to_send: List[bytes] = []
+				if code == configured_code:
+					self._authorisation_restore_pending = False
 
-			if self._successful_login:
-				modify_packet = self.int_to_bytes(int_packets[state] + section)
-				packets_to_send.append(self.create_packet_ui_control(UI_CONTROL_MODIFY_SECTION, modify_packet))
+				if not self._login_failed.is_set():
+					modify_packet = self.int_to_bytes(int_packets[state] + section)
+					self._send_packet(self.create_packet_ui_control(UI_CONTROL_MODIFY_SECTION, modify_packet))
+			finally:
+				if not self._stream_stop_event.is_set():
+					try:
+						if code != configured_code:
+							self._send_packets([
+								self.create_packet_ui_control(UI_CONTROL_AUTHORISATION_END),
+								*self.create_packets_keepalive(configured_code),
+							])
+							self._authorisation_restore_pending = False
+					finally:
+						self._stream_stop_event.wait(1.0)
 
-			if code != configured_code:
-				packets_to_send.append(self.create_packet_ui_control(UI_CONTROL_AUTHORISATION_END))
-				packets_to_send.extend(self.create_packets_keepalive(configured_code))
-
-			if packets_to_send:
-				self._hass.async_add_executor_job(self._send_packets, packets_to_send)
-
-			async_call_later(self._hass, 1.0, core.HassJob(after_modify_callback))
-
-		if code != configured_code:
-			login_packets = [
-				self.create_packet_ui_control(UI_CONTROL_AUTHORISATION_END),
-				self.create_packet_authorisation_code(code),
-			]
-
-			self._send_packets(login_packets)
-
-			self._hass.loop.call_soon_threadsafe(
-				async_call_later,
-				self._hass,
-				1.0,
-				after_login_callback,
-			)
-		else:
-			# Run the callback on the event loop so it can use async_call_later
-			# and async_add_executor_job safely from any caller thread.
-			self._hass.loop.call_soon_threadsafe(after_login_callback, None)
+			if not self._stream_stop_event.is_set():
+				self._send_packet(self.create_packet_command(COMMAND_GET_SECTIONS_AND_PG_OUTPUTS_STATES))
 
 	def toggle_pg_output(self, pg_output_number: int, state: str) -> None:
 		pg_output_number_packet = self.int_to_bytes(pg_output_number - 1)
@@ -429,7 +418,11 @@ class Jablotron:
 
 		packet = self.create_packet_ui_control(UI_CONTROL_TOGGLE_PG_OUTPUT, pg_output_number_packet + state_packet)
 
-		self._send_packet(packet)
+		with self._authorisation_lock:
+			if not self._stream_stop_event.is_set():
+				if self._authorisation_restore_pending:
+					raise ServiceUnavailable("Configured authorisation has not been restored")
+				self._send_packet(packet)
 
 	def reset_problem_sensor(self, control: JablotronControl) -> None:
 		self._update_entity_state(control.id, STATE_OFF)
@@ -1071,6 +1064,7 @@ class Jablotron:
 					self._stream_data_updating_event.set()
 
 					if not raw_packet:
+						self._login_failed.set()
 						self._set_unavailable()
 						try:
 							stream.close()
@@ -1114,7 +1108,7 @@ class Jablotron:
 							self._parse_device_status_packet(packet)
 
 						elif self._is_login_error_packet(packet):
-							self._successful_login = False
+							self._login_failed.set()
 							self._last_authorized_user_or_device = None
 							self._login_error()
 
@@ -1129,6 +1123,7 @@ class Jablotron:
 				else:
 					LOGGER.debug("Read error: %s", ex)
 
+				self._login_failed.set()
 				self._set_unavailable()
 
 				if stream is not None:
@@ -1157,7 +1152,8 @@ class Jablotron:
 			if not self._stream_data_updating_event.wait(0.5):
 				try:
 					if counter == 0 and not self._is_alarm_active():
-						self._send_packets(self.create_packets_keepalive(self._config[CONF_PASSWORD]))
+						if not self._send_keepalive():
+							continue
 
 						# Check some devices once an hour (and on the start too)
 						actual_time = datetime.datetime.now()
@@ -1183,6 +1179,21 @@ class Jablotron:
 
 			if counter == 60:
 				counter = 0
+
+	def _send_keepalive(self) -> bool:
+		if not self._authorisation_lock.acquire(blocking=False):
+			return False
+		try:
+			if self._stream_stop_event.is_set():
+				return False
+			packets = self.create_packets_keepalive(self._config[CONF_PASSWORD])
+			if self._authorisation_restore_pending:
+				packets.insert(0, self.create_packet_ui_control(UI_CONTROL_AUTHORISATION_END))
+			self._send_packets(packets)
+			self._authorisation_restore_pending = False
+			return True
+		finally:
+			self._authorisation_lock.release()
 
 	def _send_packets(self, batch: List[bytes]) -> None:
 		batch_packet = b""

--- a/tests/integration/test_alarm_authorisation.py
+++ b/tests/integration/test_alarm_authorisation.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import threading
+from unittest.mock import Mock, patch
+
+from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+import pytest
+import voluptuous as vol
+
+from custom_components.jablotron100.alarm_control_panel import JablotronAlarmControlPanelEntity
+from custom_components.jablotron100.const import EVENT_WRONG_CODE, UI_CONTROL_MODIFY_SECTION
+from custom_components.jablotron100.jablotron import JablotronAlarmControlPanel
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_alarm_service_runs_complete_transaction_off_event_loop(hass, jablotron, entity_component):
+	control = JablotronAlarmControlPanel(jablotron.central_unit(), None, "section_1", 1)
+	jablotron.entities_states[control.id] = AlarmControlPanelState.ARMED_AWAY
+	entity = JablotronAlarmControlPanelEntity(jablotron, control)
+	entity.entity_id = "alarm_control_panel.jablotron_authorisation"
+	component = entity_component("alarm_control_panel")
+	component.async_register_entity_service("alarm_disarm", {vol.Optional("code"): str}, "async_alarm_disarm")
+	loop_thread = threading.get_ident()
+	packets = []
+
+	def wait_for_response(timeout):
+		assert threading.get_ident() != loop_thread
+		assert jablotron._authorisation_lock.locked()
+		return False
+
+	try:
+		await component.async_add_entities([entity])
+		with (
+			patch.object(jablotron._stream_stop_event, "wait", side_effect=wait_for_response) as wait,
+			patch.object(jablotron, "_send_packets", side_effect=packets.extend),
+			patch.object(jablotron, "_send_packet", side_effect=packets.append),
+		):
+			await hass.services.async_call(
+				"alarm_control_panel", "alarm_disarm",
+				{"entity_id": entity.entity_id, "code": "9876"}, blocking=True,
+			)
+		assert wait.call_count == 2
+		assert jablotron.create_packet_ui_control(UI_CONTROL_MODIFY_SECTION, b"\x90") in packets
+		assert jablotron.create_packet_authorisation_code("1234") in packets
+		assert not jablotron._authorisation_lock.locked()
+		assert not jablotron._authorisation_restore_pending
+	finally:
+		await entity.async_remove()
+
+
+async def test_reader_marks_failed_login_and_preserves_wrong_code_event(hass, jablotron):
+	events = []
+	unsubscribe = hass.bus.async_listen(EVENT_WRONG_CODE, events.append)
+	stream = Mock()
+	jablotron._last_authorized_user_or_device = "User 1"
+
+	def read_packet(size):
+		jablotron._stream_stop_event.set()
+		return bytes.fromhex("80021b03")
+
+	stream.read.side_effect = read_packet
+	try:
+		with (
+			patch.object(jablotron, "_open_read_stream", return_value=stream),
+			patch("custom_components.jablotron100.jablotron.time.sleep"),
+		):
+			await hass.async_add_executor_job(jablotron._read_packets)
+		await hass.async_block_till_done()
+		assert jablotron._login_failed.is_set()
+		assert jablotron._last_authorized_user_or_device is None
+		assert len(events) == 1
+		stream.close.assert_called_once_with()
+	finally:
+		unsubscribe()
+
+
+@pytest.mark.parametrize("read_error", [False, True])
+async def test_reader_disconnect_marks_pending_login_failed(hass, jablotron, read_error):
+	stream = Mock()
+
+	def read_packet(size):
+		jablotron._stream_stop_event.set()
+		if read_error:
+			raise OSError("Synthetic read failure")
+		return b""
+
+	stream.read.side_effect = read_packet
+	with (
+		patch.object(jablotron, "_open_read_stream", return_value=stream),
+		patch.object(jablotron, "_redetect_serial_port"),
+		patch("custom_components.jablotron100.jablotron.time.sleep"),
+	):
+		await hass.async_add_executor_job(jablotron._read_packets)
+	assert jablotron._login_failed.is_set()
+	assert not jablotron.last_update_success
+	stream.close.assert_called_once_with()

--- a/tests/integration/test_code_forms.py
+++ b/tests/integration/test_code_forms.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from homeassistant.const import CONF_PASSWORD
+import pytest
+import voluptuous as vol
+
+from custom_components.jablotron100.config_flow import JablotronConfigFlow
+
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.parametrize("reconfigure", [False, True])
+async def test_code_form_uses_shared_validation(hass, jablotron, reconfigure):
+	flow = JablotronConfigFlow()
+	flow.hass = hass
+	flow._config = dict(jablotron._config)
+	result = await (flow.async_step_reconfigure_settings() if reconfigure else flow.async_step_user())
+	schema = result["data_schema"]
+	for code in ("1234", "12345678", "12*3456", "123*345678"):
+		assert schema({CONF_PASSWORD: code})[CONF_PASSWORD] == code
+	for code in ("123", "123456789", "abcd", "1234abcd", "12**3456", "1234 "):
+		with pytest.raises(vol.Invalid):
+			schema({CONF_PASSWORD: code})
+	if reconfigure:
+		assert schema({CONF_PASSWORD: ""})[CONF_PASSWORD] == ""
+	else:
+		with pytest.raises(vol.Invalid):
+			schema({CONF_PASSWORD: ""})

--- a/tests/test_authorisation_codes.py
+++ b/tests/test_authorisation_codes.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+from homeassistant.const import CONF_PASSWORD
+import pytest
+
+from custom_components.jablotron100.jablotron import Jablotron
+
+
+@pytest.mark.parametrize("code", [
+	"", "123", "123456789", "1234567890", "abcd", "123x", "1234abcd",
+	" 1234", "1234 ", "+1234", "12\n34", "\u0661\u0662\u0663\u0664",
+	"*1234", "12*", "1**1234", "1234*1234", "1*123", "1*1234567",
+])
+def test_invalid_authorisation_code_is_rejected_without_exposing_code(code):
+	with pytest.raises(ValueError, match="^Invalid authorisation code$"):
+		Jablotron.create_packet_authorisation_code(code)
+
+
+@pytest.mark.parametrize("code,expected", [
+	("1234", "80080339393931323334"),
+	("12345", "80080339393951323334"),
+	("123456", "80080339393951623334"),
+	("1234567", "80080339393951627334"),
+	("12345678", "80080339393951627384"),
+	("12*3456", "80080330313233343536"),
+	("1*345678", "80080331333435363738"),
+	("123*345678", "800a03313233333435363738"),
+])
+def test_valid_authorisation_code_keeps_wire_encoding(code, expected):
+	assert Jablotron.create_packet_authorisation_code(code) == bytes.fromhex(expected)
+
+
+@pytest.mark.parametrize("code", ["abc4", "123456789", "1**1234"])
+def test_invalid_service_code_reports_wrong_code_without_sending_packets(code):
+	jablotron = object.__new__(Jablotron)
+	jablotron._config = {CONF_PASSWORD: "1234"}
+	jablotron._hass = Mock()
+	jablotron._login_error = Mock()
+	jablotron._send_packet = Mock()
+	jablotron._send_packets = Mock()
+	jablotron.modify_alarm_control_panel_section_state(1, AlarmControlPanelState.DISARMED, code)
+	jablotron._login_error.assert_called_once_with()
+	jablotron._send_packet.assert_not_called()
+	jablotron._send_packets.assert_not_called()
+	jablotron._hass.loop.call_soon_threadsafe.assert_not_called()

--- a/tests/test_authorisation_transactions.py
+++ b/tests/test_authorisation_transactions.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+import sys
+import threading
+from unittest.mock import Mock
+
+from homeassistant import core
+from homeassistant.components.alarm_control_panel import AlarmControlPanelState
+from homeassistant.const import CONF_PASSWORD
+import pytest
+
+from custom_components.jablotron100.const import UI_CONTROL_AUTHORISATION_END, UI_CONTROL_MODIFY_SECTION
+from custom_components.jablotron100.errors import ServiceUnavailable
+from custom_components.jablotron100.jablotron import Jablotron
+
+
+@pytest.fixture
+def authorisation(monkeypatch):
+	jablotron = object.__new__(Jablotron)
+	jablotron._config = {CONF_PASSWORD: "1234"}
+	jablotron._authorisation_lock = threading.Lock()
+	jablotron._login_failed = threading.Event()
+	jablotron._authorisation_restore_pending = False
+	jablotron._stream_stop_event = Mock()
+	jablotron._stream_stop_event.is_set.return_value = False
+	jablotron._stream_stop_event.wait.return_value = False
+	jablotron._hass = Mock()
+	callbacks = deque()
+	jablotron._hass.loop.call_soon_threadsafe.side_effect = lambda callback, *args: callbacks.append((callback, args))
+	jablotron._hass.async_add_executor_job.side_effect = lambda callback, *args: callback(*args)
+	monkeypatch.setattr(core, "HassJob", lambda callback: callback, raising=False)
+	monkeypatch.setattr(
+		sys.modules[Jablotron.__module__], "async_call_later",
+		lambda hass, delay, callback: callbacks.append((callback, (None,))),
+	)
+	packets = []
+	jablotron._send_packet = Mock(side_effect=packets.append)
+	jablotron._send_packets = Mock(side_effect=packets.extend)
+	return jablotron, packets, callbacks
+
+
+def test_later_request_cannot_reset_rejected_login(authorisation):
+	jablotron, packets, callbacks = authorisation
+	wrong_login = Jablotron.create_packet_authorisation_code("9876")
+
+	def send_packets(batch):
+		packets.extend(batch)
+		if wrong_login in batch:
+			jablotron._login_failed.set()
+
+	jablotron._send_packets.side_effect = send_packets
+	jablotron.modify_alarm_control_panel_section_state(1, AlarmControlPanelState.DISARMED, "9876")
+	jablotron.modify_alarm_control_panel_section_state(2, AlarmControlPanelState.ARMED_AWAY, None)
+	while callbacks:
+		callback, args = callbacks.popleft()
+		callback(*args)
+
+	assert Jablotron.create_packet_ui_control(UI_CONTROL_MODIFY_SECTION, b"\x90") not in packets
+	assert Jablotron.create_packet_ui_control(UI_CONTROL_MODIFY_SECTION, b"\xa1") in packets
+
+
+def test_temporary_login_is_restored_before_return(authorisation):
+	jablotron, packets, callbacks = authorisation
+	jablotron.modify_alarm_control_panel_section_state(1, AlarmControlPanelState.DISARMED, "9876")
+	assert packets[:3] == [
+		Jablotron.create_packet_ui_control(UI_CONTROL_AUTHORISATION_END),
+		Jablotron.create_packet_authorisation_code("9876"),
+		Jablotron.create_packet_ui_control(UI_CONTROL_MODIFY_SECTION, b"\x90"),
+	]
+	assert packets[3:6] == [
+		Jablotron.create_packet_ui_control(UI_CONTROL_AUTHORISATION_END),
+		*Jablotron.create_packets_keepalive("1234"),
+	]
+	assert not callbacks
+	assert not jablotron._authorisation_lock.locked()
+
+
+def test_stopped_transaction_does_not_write(authorisation):
+	jablotron, packets, callbacks = authorisation
+	jablotron._stream_stop_event.is_set.return_value = True
+	jablotron.modify_alarm_control_panel_section_state(1, AlarmControlPanelState.DISARMED, "9876")
+	assert packets == []
+	assert not callbacks
+
+
+@pytest.mark.parametrize("second_action", ["alarm", "pg"])
+def test_competing_command_waits_until_temporary_login_is_restored(authorisation, second_action):
+	jablotron, packets, callbacks = authorisation
+	login_waiting = threading.Event()
+	release_login = threading.Event()
+	second_waiting = threading.Event()
+	lock = threading.Lock()
+
+	class ObservedLock:
+		def __enter__(self):
+			if lock.locked():
+				second_waiting.set()
+			lock.acquire()
+
+		def __exit__(self, *args):
+			lock.release()
+
+	jablotron._authorisation_lock = ObservedLock()
+
+	def wait_for_response(timeout):
+		if not login_waiting.is_set():
+			login_waiting.set()
+			assert release_login.wait(5)
+		return False
+
+	jablotron._stream_stop_event.wait.side_effect = wait_for_response
+	with ThreadPoolExecutor(max_workers=2) as executor:
+		first = executor.submit(jablotron.modify_alarm_control_panel_section_state, 1, AlarmControlPanelState.DISARMED, "9876")
+		try:
+			assert login_waiting.wait(5)
+			if second_action == "alarm":
+				second = executor.submit(jablotron.modify_alarm_control_panel_section_state, 2, AlarmControlPanelState.ARMED_AWAY, None)
+			else:
+				second = executor.submit(jablotron.toggle_pg_output, 1, "on")
+			assert second_waiting.wait(5)
+			assert packets == [
+				Jablotron.create_packet_ui_control(UI_CONTROL_AUTHORISATION_END),
+				Jablotron.create_packet_authorisation_code("9876"),
+			]
+		finally:
+			release_login.set()
+		first.result(timeout=5)
+		second.result(timeout=5)
+	assert packets[3:6] == [
+		Jablotron.create_packet_ui_control(UI_CONTROL_AUTHORISATION_END),
+		*Jablotron.create_packets_keepalive("1234"),
+	]
+	assert len(packets) > 7
+	assert not callbacks
+
+
+def test_keepalive_skips_busy_transaction_without_resetting_failure(authorisation):
+	jablotron, packets, callbacks = authorisation
+	jablotron._login_failed.set()
+	with jablotron._authorisation_lock:
+		assert not jablotron._send_keepalive()
+	assert packets == []
+	assert jablotron._login_failed.is_set()
+	assert jablotron._send_keepalive()
+	assert packets == Jablotron.create_packets_keepalive("1234")
+	assert jablotron._login_failed.is_set()
+
+
+@pytest.mark.parametrize("failure_stage", ["login", "modify", "restore"])
+def test_io_failure_releases_lock_and_attempts_restore(authorisation, failure_stage):
+	jablotron, packets, callbacks = authorisation
+	login = Jablotron.create_packet_authorisation_code("9876")
+	restore = Jablotron.create_packet_authorisation_code("1234")
+	modify = Jablotron.create_packet_ui_control(UI_CONTROL_MODIFY_SECTION, b"\x90")
+	failed_packet = {"login": login, "modify": modify, "restore": restore}[failure_stage]
+
+	def send_packets(batch):
+		packets.extend(batch)
+		if failed_packet in batch:
+			raise OSError("Synthetic write failure")
+
+	jablotron._send_packets.side_effect = send_packets
+	jablotron._send_packet.side_effect = lambda packet: send_packets([packet])
+	with pytest.raises(OSError, match="Synthetic write failure"):
+		jablotron.modify_alarm_control_panel_section_state(1, AlarmControlPanelState.DISARMED, "9876")
+	assert restore in packets
+	assert not jablotron._authorisation_lock.locked()
+	assert not callbacks
+	if failure_stage == "restore":
+		assert jablotron._authorisation_restore_pending
+		with pytest.raises(ServiceUnavailable):
+			jablotron.toggle_pg_output(1, "on")
+		jablotron._send_packets.side_effect = packets.extend
+		assert jablotron._send_keepalive()
+		assert packets[-3:] == [
+			Jablotron.create_packet_ui_control(UI_CONTROL_AUTHORISATION_END),
+			*Jablotron.create_packets_keepalive("1234"),
+		]
+		assert not jablotron._authorisation_restore_pending
+
+
+def test_shutdown_during_login_wait_prevents_modify_and_restore(authorisation):
+	jablotron, packets, callbacks = authorisation
+
+	def stop_during_wait(timeout):
+		jablotron._stream_stop_event.is_set.return_value = True
+		return True
+
+	jablotron._stream_stop_event.wait.side_effect = stop_during_wait
+	jablotron.modify_alarm_control_panel_section_state(1, AlarmControlPanelState.DISARMED, "9876")
+	assert len(packets) == 2
+	assert not jablotron._authorisation_lock.locked()
+	assert not callbacks


### PR DESCRIPTION
## Changes

Two fixes in separate commits, each with its tests:

1. Validate codes before encoding or submission. Plain codes accept 4-8 ASCII digits; prefixed codes accept 1-3 digits, `*`, and 4-6 digits. This prevents silent truncation and accidental hexadecimal/non-ASCII input. Setup and reconfiguration use the same validator; an empty reconfiguration field still keeps the existing code. Invalid service codes emit the existing wrong-code notification without serial writes. Error messages do not include the code.
2. Serialize alarm authorisation through a per-panel lock covering login, the response window, section modification, configured-code restoration and state refresh. Every alarm action explicitly authenticates, including configured-code actions. A later request can no longer reset an earlier request's rejection. Keepalive skips a busy transaction and PG commands wait; failed restoration blocks PG commands until recovery. Read failures mark the pending login failed, and stop interrupts response waits.

The transaction runs in HA's executor, not its event loop. It retains the existing one-second response windows rather than introducing a new positive-acknowledgement protocol. Waiting requests now complete sequentially.

## Validation

- Regression tests reproduced silent truncation and a rejected request still emitting a section command before the fixes.
- Deterministic two-thread tests cover queued alarm/PG commands, keepalive, write failures, restoration recovery and shutdown.
- Real-HA tests cover both code forms, executor service dispatch, rejection events and reader disconnects.
- Home Assistant 2026.9.1 / Python 3.14: 421 passed.
- Without Home Assistant: 386 passed, 2 skipped.
- Mypy and dependency checks passed.

No physical alarm hardware was used. The HA suite emits one existing HTTP application deprecation warning.